### PR TITLE
Include license file with source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include ndindex/_version.py
+include LICENSE


### PR DESCRIPTION
This PR adds the license file to the `MANIFEST.in` so that it is included with the source distribution