### PR TITLE
Enable the doctest_standalone_namespace flag in the tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --doctest-modules --doctest-glob=*.md
+doctest_standalone_namespace = True


### PR DESCRIPTION
This flag isn't supported in pytest yet. It will be once
https://github.com/pytest-dev/pytest/pull/6978 is merged. However, I would
recommend waiting until that PR is merged to merge this since the name of the
flag may change.

The flag will make it so that the doctests require all names to be imported in
order to pass, as opposed to the default behavior which automatically includes
all names from the surrounding module in the doctest namespace.