### PR TITLE
Add __signature__ to NDIndex

### DIFF
--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -1,4 +1,5 @@
 import operator
+import inspect
 
 from numpy import ndarray
 
@@ -29,6 +30,12 @@ def ndindex(obj):
         return Tuple(*obj)
 
     raise TypeError(f"Don't know how to convert object of type {type(obj)} to an ndindex object")
+
+class classproperty(object):
+    def __init__(self, f):
+        self.f = f
+    def __get__(self, obj, owner):
+        return self.f(owner)
 
 class NDIndex:
     """
@@ -79,6 +86,17 @@ class NDIndex:
         """
         args = self._typecheck(*args)
         self.args = args
+
+    @classproperty
+    def __signature__(self):
+        """
+        Allow Python 3's inspect.signature to give a useful signature for
+        NDIndex subclasses.
+        """
+        sig = inspect.signature(self._typecheck)
+        d = dict(sig.parameters)
+        d.pop('self')
+        return inspect.Signature(d.values())
 
     def __repr__(self):
         return f"{self.__class__.__name__}({', '.join(map(str, self.args))})"

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -38,6 +38,7 @@ exhaustive test should have a corresponding hypothesis test.
 """
 
 from itertools import chain, product
+import inspect
 
 from pytest import raises
 
@@ -329,3 +330,7 @@ def test_tuple_reduce_hypothesis(t, shape):
 
     check_same(a, idx.raw, func=lambda x: x.reduce(shape),
                same_exception=False)
+
+def test_signature():
+    sig = inspect.signature(Integer)
+    assert sig.parameters.keys() == {'idx'}


### PR DESCRIPTION
This makes inspect.signature() give the correct thing for ndindex subclasses.