### PR TITLE
Fix Tuple.reduce() with no arguments

### DIFF
--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -627,6 +627,9 @@ class Tuple(NDIndex):
         if len(self.args) == 1:
             return self.args[0].reduce(shape)
 
+        if shape is None:
+            return self
+
         if isinstance(shape, int):
             shape = (shape,)
         if len(shape) < len(self.args):

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -282,6 +282,16 @@ def test_integer_reduce_hypothesis(i, shape):
     else:
         assert reduced.raw >= 0
 
+def test_integer_reduce_no_shape_exhaustive():
+    a = arange(10)
+    for i in range(-12, 12):
+        check_same(a, i, func=lambda x: x.reduce())
+
+@given(integers(0, 10), integers(0, 10))
+def test_integer_reduce_no_shape_hypothesis(i, size):
+    a = arange(size)
+    check_same(a, i, func=lambda x: x.reduce())
+
 def test_tuple_exhaustive():
     # Exhaustive tests here have to be very limited because of combinatorial
     # explosion.
@@ -328,4 +338,17 @@ def test_tuple_reduce_hypothesis(t, shape):
         assume(False)
 
     check_same(a, idx.raw, func=lambda x: x.reduce(shape),
+               same_exception=False)
+
+
+@given(Tuples, integers(0, 10))
+def test_tuple_reduce_no_shape_hypothesis(t, size):
+    a = arange(size)
+
+    try:
+        idx = Tuple(*t)
+    except ValueError:
+        assume(False)
+
+    check_same(a, idx.raw, func=lambda x: x.reduce(),
                same_exception=False)


### PR DESCRIPTION
Also add tests for Tuple.reduce() and Integer.reduce() with no arguments.