### PR TITLE
Fix a bug in NDIndex.__eq__

### DIFF
--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -84,8 +84,14 @@ class NDIndex:
         return f"{self.__class__.__name__}({', '.join(map(str, self.args))})"
 
     def __eq__(self, other):
+        if not isinstance(other, NDIndex):
+            try:
+                other = ndindex(other)
+            except (TypeError, NotImplementedError):
+                return False
+
         return ((isinstance(other, self.__class__)
-                 or isinstance(self, other.__eq__))
+                 or isinstance(self, other.__class__))
                 and self.args == other.args)
 
     def __hash__(self):

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -315,9 +315,15 @@ def test_tuples_hypothesis(idx, shape):
 @given(ndindices())
 def test_eq(idx):
     new = type(idx)(*idx.args)
-    assert new == idx
-    assert new.raw == idx.raw
+    assert (new == idx) is True
+    assert (new.raw == idx.raw) is True
     assert hash(new) == hash(idx)
+    assert (idx == idx.raw) is True
+    assert (idx.raw == idx) is True
+    assert (idx == 'a') is False
+    assert ('a' == idx) is False
+    assert (idx != 'a') is True
+    assert ('a' != idx) is True
 
 @given(Tuples, shapes)
 def test_tuple_reduce_hypothesis(t, shape):


### PR DESCRIPTION
Also make == give True when comparing against objects that can be converted to
an equivalent ndindex type.