### PR TITLE
Coverage fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,9 @@
 omit = ndindex/_version.py
 
 [report]
-exclude_lines = raise NotImplementedError
+exclude_lines =
+    raise NotImplementedError
+    pragma: no cover
 
 # Require full coverage. Lines that cannot be covered can be added as regexes
 # above, or excluded using # pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,9 @@
-[report]
-exclude_lines = raise NotImplementedError
 [run]
 omit = ndindex/_version.py
+
+[report]
+exclude_lines = raise NotImplementedError
+
+# Require full coverage. Lines that cannot be covered can be added as regexes
+# above, or excluded using # pragma: no cover
+fail_under = 100

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines = raise NotImplementedError
+[run]
+omit = ndindex/_version.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,4 @@ exclude_lines = raise NotImplementedError
 
 # Require full coverage. Lines that cannot be covered can be added as regexes
 # above, or excluded using # pragma: no cover
-fail_under = 100
+# fail_under = 100

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,4 @@ exclude_lines = raise NotImplementedError
 
 # Require full coverage. Lines that cannot be covered can be added as regexes
 # above, or excluded using # pragma: no cover
-# fail_under = 100
+fail_under = 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ script:
   - if [[ "${COVERAGE}" == "true" ]]; then
         bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
     fi
-  - coverage report -m;
+  - coverage report -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
   - PYTEST_FLAGS="$PYTEST_FLAGS -v"
   - if [[ "${COVERAGE}" == "true" ]]; then
-        PYTEST_FLAGS="$PYTEST_FLAGS --cov=./";
+        PYTEST_FLAGS="$PYTEST_FLAGS --cov-fail-under=0";
     fi
   - pytest $PYTEST_FLAGS
   # Make sure it installs
@@ -52,4 +52,5 @@ script:
     fi
   - if [[ "${COVERAGE}" == "true" ]]; then
         bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
+        coverage report -m;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,8 @@ script:
   - set -e
   - pyflakes .
   - python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
-  - PYTEST_FLAGS="$PYTEST_FLAGS -v"
-  - if [[ "${COVERAGE}" == "true" ]]; then
-        PYTEST_FLAGS="$PYTEST_FLAGS --cov-fail-under=0";
-    fi
+  # The coverage requirement check is done by the coverage report line below
+  - PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
   - pytest $PYTEST_FLAGS
   # Make sure it installs
   - python setup.py install
@@ -53,4 +51,7 @@ script:
   - if [[ "${COVERAGE}" == "true" ]]; then
         bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
     fi
+  # Here in case codecov fails. Also codecov won't set a status if the tests
+  # fail, so we have to require the coverage separately after the coverage is
+  # uploaded to codecov.
   - coverage report -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ script:
     fi
   - if [[ "${COVERAGE}" == "true" ]]; then
         bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
-        coverage report -m;
     fi
+  - coverage report -m;

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ script:
   - if [[ "${COVERAGE}" == "true" ]]; then
         bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
     fi
-  # Here in case codecov fails. Also codecov won't set a status if the tests
-  # fail, so we have to require the coverage separately after the coverage is
-  # uploaded to codecov.
+  # Here in case codecov fails. This also sets the failing status if the
+  # coverage is not 100%.
   - coverage report -m

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
     patch: off
     project:
       default:
+        threshold: 0%
         informational: true
         if_ci_failed: error
     changes: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,8 @@
 comment: false
 coverage:
   status:
-    project: off
-    patch:
+    patch: off
+    project:
       default:
         informational: true
     changes: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,5 @@ coverage:
     project:
       default:
         informational: true
+        if_ci_failed: error
     changes: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,5 @@ coverage:
     patch: off
     project:
       default:
-        threshold: 0%
         informational: true
-        if_ci_failed: error
     changes: off

--- a/ndindex/tests/__init__.py
+++ b/ndindex/tests/__init__.py
@@ -31,9 +31,14 @@ to Slice(-2, -1, -1). Another reason for the duplication is that hypothesis
 can sometimes test a slightly expanded test space without any additional
 consequences. For example, test_slice_reduce_hypothesis() tests all types of
 array shapes, whereas test_slice_reduce_exhaustive() tests only 1-dimensional
-shapes. This doesn't affect things because hypotheses will always shrink large
+shapes. This doesn't affect things because hypothesis will always shrink large
 shapes to a 1-dimensional shape in the case of a failure. Consequently every
 exhaustive test should have a corresponding hypothesis test.
+
+For things that can only be tested with hypothesis, you can use @example, to
+force certain combinations to be tested. This is useful because we require
+100% test coverage, and hypothesis's randomness can cause this to be flaky
+otherwise.
 
 """
 

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -74,13 +74,13 @@ def check_same(a, index, func=lambda x: x, same_exception=True):
         a_idx = a[idx.raw]
     except Exception as e:
         if not exception:
-            fail(f"Raw form does not raise but ndindex form does ({e!r}): {index})")
+            fail(f"Raw form does not raise but ndindex form does ({e!r}): {index})") # pragma: no cover
         if same_exception:
             assert type(e) == type(exception), (e, exception)
             assert e.args == exception.args, (e.args, exception.args)
     else:
         if exception:
-            fail(f"ndindex form did not raise but raw form does ({exception!r}): {index})")
+            fail(f"ndindex form did not raise but raw form does ({exception!r}): {index})") # pragma: no cover
 
     if not exception:
         assert_equal(a_raw, a_idx)

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -2,8 +2,11 @@ import inspect
 
 from hypothesis import given
 
+from pytest import raises
+
 from ..ndindex import ndindex
 from ..integer import Integer
+from ..ellipsis import ellipsis
 from .helpers import ndindices
 
 @given(ndindices())
@@ -25,6 +28,9 @@ def test_ndindex(idx):
     assert ndindex(idx).raw == idx
     ix = ndindex(idx)
     assert ndindex(ix.raw) == ix
+
+def test_ndindex_ellipsis():
+    raises(TypeError, lambda: ndindex(ellipsis))
 
 def test_signature():
     sig = inspect.signature(Integer)

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -2,7 +2,7 @@ from itertools import product
 
 from numpy import arange
 
-from hypothesis import given, assume
+from hypothesis import given, assume, example
 from hypothesis.strategies import integers, one_of
 
 from ..ndindex import ndindex
@@ -59,6 +59,7 @@ def test_ellipsis_index(t, shape):
             # Don't know if there is a better way to test ellipsis_idx
             check_same(a, t, func=lambda x: ndindex((*x.raw[:x.ellipsis_index], ..., *x.raw[x.ellipsis_index+1:])))
 
+@example((0, 1, ..., 2, 3), (5, 5, 5, 5, 5, 5))
 @given(Tuples, one_of(shapes, integers(0, 10)))
 def test_tuple_reduce_hypothesis(t, shape):
     if isinstance(shape, int):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --doctest-modules --doctest-glob=*.md --cov=ndindex/
+addopts = --doctest-modules --doctest-glob=*.md --cov=ndindex/ --cov-report=term-missing
 doctest_optionflags= NORMALIZE_WHITESPACE

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --doctest-modules --doctest-glob=*.md
+addopts = --doctest-modules --doctest-glob=*.md --cov=ndindex/
 doctest_optionflags= NORMALIZE_WHITESPACE


### PR DESCRIPTION
I was thinking it might be a good idea to require 100% coverage (with select 'no cover' lines), but codecov might be too buggy. We can already see some of the issues with codecov https://codecov.io/gh/Quansight/ndindex/compare/9bd57a3c93d56bb9ee8f7b3984145d772ab8b2d7...51edc3bad7667c84309c1e03c7e57324cdb1a09f/src/ndindex/tuple.py?before=ndindex/tuple.py. I guess we can require the coverage in Travis, and just use codecov as a way of seeing the coverage. 