### PR TITLE
Make Tuple.reduce(shape) reduce more

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ author = 'Quansight'
 extensions = [
     'recommonmark',
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
 ]
 
 import commonmark

--- a/ndindex/ellipsis.py
+++ b/ndindex/ellipsis.py
@@ -53,6 +53,14 @@ class ellipsis(NDIndex):
         >>> ellipsis().reduce()
         Tuple()
 
+        See Also
+        ========
+
+        .NDIndex.reduce
+        .Tuple.reduce
+        .Slice.reduce
+        .Integer.reduce
+
         """
         return Tuple()
 

--- a/ndindex/ellipsis.py
+++ b/ndindex/ellipsis.py
@@ -31,9 +31,11 @@ class ellipsis(NDIndex):
 
     **Note:** Unlike the standard Python `Ellipsis`, `ellipsis` is the type,
     not the object (the name is lowercase to avoid conflicting with the
-    built-in). Use `ellipsis()` or `ndindex(...)` to create the object. Also
-    unlike `Ellipsis`, `ellipsis()` is not singletonized, so you should not
-    use `is` to compare it.
+    built-in). Use `ellipsis()` or `ndindex(...)` to create the object. In
+    most ndindex contexts, `...` can be used instead of `ellipsis()`, for
+    instance, when creating a `Tuple` object. Also unlike `Ellipsis`,
+    `ellipsis()` is not singletonized, so you should not use `is` to compare
+    it.
 
     """
     def _typecheck(self):

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -16,9 +16,9 @@ class Integer(NDIndex):
     >>> [0, 1, 2][idx.raw]
     0
 
-    Note that Integer itself implements `__index__`, so it can be used as an
+    Note that `Integer` itself implements `__index__`, so it can be used as an
     index directly. However, it is still recommended to use `raw` for
-    consistency, as this only works for Integer.
+    consistency, as this only works for `Integer`.
 
     """
     def _typecheck(self, idx):

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -58,6 +58,14 @@ class Integer(NDIndex):
         >>> idx.reduce((9,))
         Integer(4)
 
+        See Also
+        ========
+
+        .NDIndex.reduce
+        .Tuple.reduce
+        .Slice.reduce
+        .ellipsis.reduce
+
         """
         if shape is None:
             return self

--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -171,6 +171,40 @@ class NDIndex:
         For single axis indices such as Slice and Tuple, `reduce` takes an
         optional `axis` argument to specify the axis, defaulting to 0.
 
+        See Also
+        ========
+
+        .Integer.reduce
+        .Tuple.reduce
+        .Slice.reduce
+        .ellipsis.reduce
+
         """
         # XXX: Should the default be raise NotImplementedError or return self?
         raise NotImplementedError
+
+    def expand(self, shape):
+        """
+        Expand an index on an array of shape `shape`
+
+        An expanded index is as explicit as possible. Unlike `reduce`, which
+        tries to simplify an index and remove redundancies, `expand` typically
+        makes an index larger.
+
+        `expand` always returns a `Tuple` whose `.args` is the same length as
+        `shape`. See :meth:`.Tuple.expand` for more details on the behavior of
+        `expand`.
+
+        >>> from ndindex import Slice
+        >>> Slice(None).expand((2, 3))
+        Tuple(slice(0, 2, 1), slice(0, 3, 1))
+
+        See Also
+        ========
+
+        .Tuple.expand
+
+        """
+        from .tuple import Tuple
+
+        return Tuple(self).expand(shape)

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -250,6 +250,14 @@ class Slice(NDIndex):
           >>> len(_)
           3
 
+        See Also
+        ========
+
+        .NDIndex.reduce
+        .Tuple.reduce
+        .Integer.reduce
+        .ellipsis.reduce
+
         """
         start, stop, step = self.args
 

--- a/ndindex/tests/__init__.py
+++ b/ndindex/tests/__init__.py
@@ -3,7 +3,7 @@ Tests are extremely important for ndindex. All operations should produce
 correct results. We test this by checking against numpy arange (the array
 values do not matter, so long as they are distinct).
 
-There are two primary types of tests that we employ to verify this:
+There are three primary types of tests that we employ to verify this:
 
 - Exhaustive tests. These test every possible value in some range. See for
   example test_slice. This is the best type of test, but unfortunately, it is
@@ -14,6 +14,12 @@ There are two primary types of tests that we employ to verify this:
   can generate all the relevant types of indices (see helpers.py). For more
   information on hypothesis, see
   https://hypothesis.readthedocs.io/en/latest/index.html.
+
+- Explicit tests. These are hand crafted tests that test that the output of a
+  function is some exact value. These are used when a property-based test is
+  difficult to write, and it is simpler to test the exact output value. These
+  tests still include a correctness check (check_same()) to make sure the
+  hard-coded output is actually correct.
 
 The basic idea in both cases is the same. Take the pure index and the
 ndindex(index).raw, or in the case of a transformation, the before and after

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -148,6 +148,8 @@ def test_slice_reduce_exhaustive():
             check_same(a, S.raw, func=lambda x: x.reduce((n,)))
 
             # Check the conditions stated by the Slice.reduce() docstring
+            # TODO: Factor this out so we can also test it in the tuple reduce
+            # tests.
             reduced = S.reduce((n,))
             assert reduced.start >= 0
             # We cannot require stop > 0 because if stop = None and step < 0, the

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -82,6 +82,8 @@ def test_tuple_reduce_no_shape_hypothesis(t, shape):
 @example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
 @example((0, slice(None), ..., slice(None), 3), (2, 3, 4, 5, 6, 7))
 @example((0, ..., slice(None)), (2, 3, 4, 5, 6, 7))
+@example((slice(None, None, -1),), (2,))
+@example((..., slice(None, None, -1),), (2, 3, 4))
 @given(Tuples, one_of(shapes, integers(0, 10)))
 def test_tuple_reduce_hypothesis(t, shape):
     if isinstance(shape, int):

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -92,15 +92,15 @@ def test_tuple_reduce_hypothesis(t, shape):
         a = arange(prod(shape)).reshape(shape)
 
     try:
-        idx = Tuple(*t)
+        index = Tuple(*t)
     except (IndexError, ValueError):
         assume(False)
 
-    check_same(a, idx.raw, func=lambda x: x.reduce(shape),
+    check_same(a, index.raw, func=lambda x: x.reduce(shape),
                same_exception=False)
 
     try:
-        reduced = idx.reduce(shape)
+        reduced = index.reduce(shape)
     except IndexError:
         pass
     else:
@@ -118,15 +118,15 @@ def test_tuple_expand_hypothesis(t, shape):
         a = arange(prod(shape)).reshape(shape)
 
     try:
-        idx = Tuple(*t)
+        index = Tuple(*t)
     except (IndexError, ValueError):
         assume(False)
 
-    check_same(a, idx.raw, func=lambda x: x.expand(shape),
+    check_same(a, index.raw, func=lambda x: x.expand(shape),
                same_exception=False)
 
     try:
-        expanded = idx.expand(shape)
+        expanded = index.expand(shape)
     except IndexError:
         pass
     else:

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -7,8 +7,8 @@ from hypothesis.strategies import integers, one_of
 
 from ..ndindex import ndindex
 from ..tuple import Tuple
-from .helpers import check_same, Tuples, prod, shapes, iterslice
 from ..integer import Integer
+from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices
 
 
 def test_tuple_exhaustive():
@@ -153,6 +153,32 @@ def test_tuple_expand_hypothesis(t, shape):
     except IndexError:
         pass
     else:
+        assert isinstance(expanded, Tuple)
+        assert ... not in expanded.args
+        if isinstance(shape, int):
+            assert len(expanded.args) == 1
+        else:
+            assert len(expanded.args) == len(shape)
+
+@given(ndindices(), one_of(shapes, integers(0, 10)))
+def test_ndindex_expand_hypothesis(idx, shape):
+    if isinstance(shape, int):
+        a = arange(shape)
+    else:
+        a = arange(prod(shape)).reshape(shape)
+
+    index = ndindex(idx)
+
+    check_same(a, index.raw, func=lambda x: x.expand(shape),
+               same_exception=False)
+
+
+    try:
+        expanded = index.expand(shape)
+    except IndexError:
+        pass
+    else:
+        assert isinstance(expanded, Tuple)
         assert ... not in expanded.args
         if isinstance(shape, int):
             assert len(expanded.args) == 1

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -166,7 +166,11 @@ class Tuple(NDIndex):
         See Also
         ========
 
-        Tuple.expand
+        .Tuple.expand
+        .NDIndex.reduce
+        .Slice.reduce
+        .Integer.reduce
+        .ellipsis.reduce
 
         """
         from .ellipsis import ellipsis
@@ -266,7 +270,8 @@ class Tuple(NDIndex):
         See Also
         ========
 
-        Tuple.reduce
+        .Tuple.reduce
+        .NDIndex.expand
 
         """
         from .ellipsis import ellipsis

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -71,7 +71,8 @@ class Tuple(NDIndex):
         Give the index i of `self.args` where the ellipsis is.
 
         If `self` doesn't have an ellipsis, it gives `len(self.args)`, since
-        tuple indices always implicitly end in an ellipsis.
+        tuple indices without an ellipsis always implicitly end in an
+        ellipsis.
 
         The resulting value `i` is such that `self.args[:i]` indexes the
         beginning axes of an array and `self.args[i+1:]` indexes the end axes

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -192,7 +192,7 @@ class Tuple(NDIndex):
             reduced = s.reduce(shape, axis=ellipsis_i - i)
             if (removable
                 and isinstance(reduced, Slice)
-                and reduced == Slice(0, shape[ellipsis_i - i])):
+                and reduced == Slice(0, shape[ellipsis_i - i], 1)):
                 continue
             else:
                 removable = False
@@ -208,7 +208,7 @@ class Tuple(NDIndex):
             reduced = s.reduce(shape, axis=axis)
             if (removable
                 and isinstance(reduced, Slice)
-                and reduced == Slice(0, shape[axis])):
+                and reduced == Slice(0, shape[axis], 1)):
                 continue
             else:
                 removable = False

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -190,7 +190,9 @@ class Tuple(NDIndex):
         removable = shape is not None
         for i, s in enumerate(reversed(args[:ellipsis_i]), start=1):
             reduced = s.reduce(shape, axis=ellipsis_i - i)
-            if removable and isinstance(reduced, Slice) and len(reduced) == shape[ellipsis_i - i]:
+            if (removable
+                and isinstance(reduced, Slice)
+                and reduced == Slice(0, shape[ellipsis_i - i])):
                 continue
             else:
                 removable = False
@@ -204,7 +206,9 @@ class Tuple(NDIndex):
                 # Make the axis positive so the error messages will match numpy
                 axis += len(shape)
             reduced = s.reduce(shape, axis=axis)
-            if removable and isinstance(reduced, Slice) and len(reduced) == shape[axis]:
+            if (removable
+                and isinstance(reduced, Slice)
+                and reduced == Slice(0, shape[axis])):
                 continue
             else:
                 removable = False


### PR DESCRIPTION
Now it always returns a Tuple with the same number of items as the shape (or
the single argument in the case of len(shape) == 1), and that has no ellipses.

Fixes #18