### PR TITLE
Remove assume(False) lines from test coverage

### DIFF
--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -53,7 +53,7 @@ def ndindices(draw):
 
     try:
         return ndindex(s)
-    except ValueError:
+    except ValueError: # pragma: no cover
         assume(False)
 
 shapes = tuples(integers(0, 10)).filter(

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -74,7 +74,7 @@ def test_slice_len_exhaustive():
 def test_slice_len_hypothesis(s):
     try:
         S = Slice(s)
-    except ValueError:
+    except ValueError: # pragma: no cover
         assume(False)
     try:
         l = len(S)
@@ -123,7 +123,7 @@ def test_slice_reduce_no_shape_hypothesis(s, shape):
     a = arange(prod(shape)).reshape(shape)
     try:
         S = Slice(s)
-    except ValueError:
+    except ValueError: # pragma: no cover
         assume(False)
 
     # The axis argument is tested implicitly in the Tuple.reduce test. It is
@@ -163,7 +163,7 @@ def test_slice_reduce_hypothesis(s, shape):
     a = arange(prod(shape)).reshape(shape)
     try:
         S = Slice(s)
-    except ValueError:
+    except ValueError: # pragma: no cover
         assume(False)
 
     # The axis argument is tested implicitly in the Tuple.reduce test. It is

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -69,7 +69,7 @@ def test_tuple_reduce_no_shape_hypothesis(t, shape):
 
     try:
         idx = Tuple(*t)
-    except (IndexError, ValueError):
+    except (IndexError, ValueError): # pragma: no cover
         assume(False)
 
     check_same(a, idx.raw, func=lambda x: x.reduce(),
@@ -94,7 +94,7 @@ def test_tuple_reduce_hypothesis(t, shape):
 
     try:
         index = Tuple(*t)
-    except (IndexError, ValueError):
+    except (IndexError, ValueError): # pragma: no cover
         assume(False)
 
     check_same(a, index.raw, func=lambda x: x.reduce(shape),
@@ -142,7 +142,7 @@ def test_tuple_expand_hypothesis(t, shape):
 
     try:
         index = Tuple(*t)
-    except (IndexError, ValueError):
+    except (IndexError, ValueError): # pragma: no cover
         assume(False)
 
     check_same(a, index.raw, func=lambda x: x.expand(shape),


### PR DESCRIPTION
Hypothesis might not generate invalid tests, but we don't want this to fail
the coverage.

I couldn't figure out a way to do this with coveragerc, since it's two lines that need to be removed and exclude_lines only seems to work line-by-line.