### PR TITLE
More work on as_subindex

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,3 +3,28 @@ import sys
 sys.path.insert(0, '.')
 
 collect_ignore = ["setup.py", "docs/conf.py"]
+
+# Add a --hypothesis-max-examples flag to pytest. See
+# https://github.com/HypothesisWorks/hypothesis/issues/2434#issuecomment-630309150
+
+def pytest_addoption(parser):
+    # Add an option to change the Hypothesis max_examples setting.
+    parser.addoption(
+        "--hypothesis-max-examples",
+        action="store",
+        default=None,
+        help="set the Hypothesis max_examples setting",
+    )
+
+
+def pytest_configure(config):
+    # Set Hypothesis max_examples.
+    hypothesis_max_examples = config.getoption("--hypothesis-max-examples")
+    if hypothesis_max_examples is not None:
+        import hypothesis
+
+        hypothesis.settings.register_profile(
+            "hypothesis-overridden", max_examples=int(hypothesis_max_examples)
+        )
+
+        hypothesis.settings.load_profile("hypothesis-overridden")

--- a/ndindex/ellipsis.py
+++ b/ndindex/ellipsis.py
@@ -67,3 +67,6 @@ class ellipsis(NDIndex):
     @property
     def raw(self):
         return ...
+
+    def as_subindex(self, index):
+        return Tuple().as_subindex(index)

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -83,3 +83,14 @@ class Integer(NDIndex):
             return self.__class__(size + self.raw)
 
         return self
+
+    def as_subindex(self, index):
+        from .ndindex import ndindex
+        from .slice import Slice
+
+        index = ndindex(index)
+
+        if not isinstance(index, Slice):
+            raise NotImplementedError("Tuple.as_subindex is only implemented for slices")
+
+        return Slice(self.args[0], self.args[0] + 1).as_subindex(index)

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -93,4 +93,9 @@ class Integer(NDIndex):
         if not isinstance(index, Slice):
             raise NotImplementedError("Tuple.as_subindex is only implemented for slices")
 
-        return Slice(self.args[0], self.args[0] + 1).as_subindex(index)
+        s = Slice(self.args[0], self.args[0] + 1).as_subindex(index)
+        if s == Slice(0, 0, 1):
+            # Return a slice so that the result doesn't produce an IndexError
+            return s
+        assert len(s) == 1
+        return Integer(s.args[0])

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -87,8 +87,12 @@ class Integer(NDIndex):
     def as_subindex(self, index):
         from .ndindex import ndindex
         from .slice import Slice
+        from .tuple import Tuple
 
         index = ndindex(index)
+
+        if isinstance(index, Tuple):
+            return Tuple(self).as_subindex(index)
 
         if not isinstance(index, Slice):
             raise NotImplementedError("Tuple.as_subindex is only implemented for slices")

--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -257,10 +257,10 @@ class NDIndex:
                 |                           |
                 +- self.as_subindex(index) -+
 
-        `i.as_subindex(j)` is currently only implemented when `i` and `j` are
-        slices with positive steps and nonnegative start and stop. To use it
-        with slices with negative start or stop, call :meth:`reduce` with a shape
-        first.
+        `i.as_subindex(j)` is currently only implemented when `j` is a slices
+        with positive steps and nonnegative start and stop, or a Tuple of the
+        same. To use it with slices with negative start or stop, call
+        :meth:`reduce` with a shape first.
 
         `as_subindex` can be seen as the left-inverse of composition, that is,
         if `i = j[k]`, that is, `a[i] = a[j][k]`, then `k = i.as_subindex(j)`,

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -355,17 +355,17 @@ class Slice(NDIndex):
             return Tuple(self).as_subindex(index)
 
         if not isinstance(index, Slice):
-            raise NotImplementedError("Slice.as_subindex is only implemented for slices")
+            raise NotImplementedError("Slice.as_subindex() is only implemented for tuples and slices")
 
         s = self.reduce()
         index = index.reduce()
 
         if s.step < 0 or index.step < 0:
-            raise NotImplementedError("Slice.as_subindex is only implemented for slices with positive steps")
+            raise NotImplementedError("Slice.as_subindex() is only implemented for slices with positive steps")
 
         # After reducing, start is not None when step > 0
         if index.stop is None or s.stop is None or s.start < 0 or index.start < 0 or s.stop < 0 or index.stop < 0:
-            raise NotImplementedError("Slice.as_subindex is only implemented for slices with nonnegative start and stop. Try calling reduce() with a shape first.")
+            raise NotImplementedError("Slice.as_subindex() is only implemented for slices with nonnegative start and stop. Try calling reduce() with a shape first.")
 
         # Chinese Remainder Theorem. We are looking for a solution to
         #

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -396,4 +396,4 @@ class Slice(NDIndex):
         if stop < 0:
             stop = 0
 
-        return Slice(start, stop, step)
+        return Slice(start, stop, step).reduce()

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -347,7 +347,12 @@ class Slice(NDIndex):
         # this is the only method that is actually implemented so far.
 
         from .ndindex import ndindex
+        from .tuple import Tuple
+
         index = ndindex(index)
+
+        if isinstance(index, Tuple):
+            return Tuple(self).as_subindex(index)
 
         if not isinstance(index, Slice):
             raise NotImplementedError("Slice.as_subindex is only implemented for slices")

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -29,9 +29,6 @@ def slices(start=one_of(none(), ints()), stop=one_of(none(), ints()),
            step=one_of(none(), ints())):
     return builds(slice, start, stop, step)
 
-positive_slices = slices(start=integers(0, 10), stop=integers(0, 10),
-                         step=integers(1, 10))
-
 ellipses = lambda: just(...)
 
 # hypotheses.strategies.tuples only generates tuples of a fixed size

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -30,6 +30,9 @@ def slices(draw, start=one_of(none(), ints()), stop=one_of(none(), ints()),
            step=one_of(none(), ints())):
     return slice(draw(start), draw(stop), draw(step))
 
+positive_slices = slices(start=integers(0, 10), stop=integers(0, 10),
+                         step=integers(1, 10))
+
 ellipses = lambda: just(...)
 
 # hypotheses.strategies.tuples only generates tuples of a fixed size

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -11,7 +11,7 @@ from ..tuple import Tuple
 from ..slice import Slice
 from ..integer import Integer
 from ..ellipsis import ellipsis
-from .helpers import (check_same, prod, shapes, ellipses, positive_slices, Tuples)
+from .helpers import check_same, prod, shapes, ellipses, slices, Tuples
 
 def test_ellipsis_exhaustive():
     for n in range(10):
@@ -67,7 +67,7 @@ def test_ellipsis_newshape_ndindex_input():
     raises(TypeError, lambda: ellipsis().newshape(Tuple(2, 1)))
     raises(TypeError, lambda: ellipsis().newshape(Integer(2)))
 
-@given(ellipses(), positive_slices, shapes)
+@given(ellipses(), slices(), shapes)
 def test_ellipsis_as_subindex_slice_hypothesis(idx, index, shape):
     a = arange(prod(shape)).reshape(shape)
 

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -38,7 +38,7 @@ def test_ellipsis_reduce_no_shape_hypothesis(idx, shape):
     check_same(a, idx, func=lambda x: x.reduce())
 
 @given(ellipses(), positive_slices, shapes)
-def test_tuple_as_subindex_slice_hypothesis(idx, index, shape):
+def test_ellipsis_as_subindex_slice_hypothesis(idx, index, shape):
     a = arange(prod(shape)).reshape(shape)
 
     E = ndindex(idx)
@@ -62,7 +62,7 @@ def test_tuple_as_subindex_slice_hypothesis(idx, index, shape):
     assert asubindex == aE.intersection(aindex)
 
 @given(ellipses(), Tuples, shapes)
-def test_tuple_as_subindex_tuple_hypothesis(idx, index, shape):
+def test_ellipsis_as_subindex_tuple_hypothesis(idx, index, shape):
     a = arange(prod(shape)).reshape(shape)
 
     E = ndindex(idx)

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -51,7 +51,7 @@ def test_ellipsis_as_subindex_slice_hypothesis(idx, index, shape):
     try:
         Subindex = E.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
+        return
 
     try:
         aE = a[idx]
@@ -75,7 +75,7 @@ def test_ellipsis_as_subindex_tuple_hypothesis(idx, index, shape):
     try:
         Subindex = E.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
+        return
 
     try:
         aE = a[idx]

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -1,4 +1,5 @@
-from numpy import arange
+from numpy import arange, isin
+from numpy.testing import assert_equal
 
 from hypothesis import given, assume
 
@@ -53,13 +54,13 @@ def test_ellipsis_as_subindex_slice_hypothesis(idx, index, shape):
         assume(False)
 
     try:
-        aE = set(a[idx].flat)
-        aindex = set(a[index].flat)
+        aE = a[idx]
+        aindex = a[index]
     except IndexError: # pragma: no cover
         assume(False)
-    asubindex = set(a[index][Subindex.raw].flat)
+    asubindex = aindex[Subindex.raw]
 
-    assert asubindex == aE.intersection(aindex)
+    assert_equal(asubindex.flatten(), aE[isin(aE, aindex)])
 
 @given(ellipses(), Tuples, shapes)
 def test_ellipsis_as_subindex_tuple_hypothesis(idx, index, shape):
@@ -77,10 +78,10 @@ def test_ellipsis_as_subindex_tuple_hypothesis(idx, index, shape):
         assume(False)
 
     try:
-        aE = set(a[idx].flat)
-        aindex = set(a[index].flat)
+        aE = a[idx]
+        aindex = a[index]
     except IndexError: # pragma: no cover
         assume(False)
-    asubindex = set(a[index][Subindex.raw].flat)
+    asubindex = aindex[Subindex.raw]
 
-    assert asubindex == aE.intersection(aindex)
+    assert_equal(asubindex.flatten(), aE[isin(aE, aindex)])

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -4,7 +4,8 @@ from hypothesis import given, assume
 
 from ..ndindex import ndindex
 from ..slice import Slice
-from .helpers import check_same, prod, shapes, ellipses, positive_slices
+from ..tuple import Tuple
+from .helpers import (check_same, prod, shapes, ellipses, positive_slices, Tuples)
 
 def test_ellipsis_exhaustive():
     for n in range(10):
@@ -43,6 +44,30 @@ def test_tuple_as_subindex_slice_hypothesis(idx, index, shape):
     E = ndindex(idx)
     try:
         Index = Slice(index)
+    except (IndexError, ValueError): # pragma: no cover
+        assume(False)
+
+    try:
+        Subindex = E.as_subindex(Index)
+    except NotImplementedError: # pragma: no cover
+        assume(False)
+
+    try:
+        aE = set(a[idx].flat)
+        aindex = set(a[index].flat)
+    except IndexError: # pragma: no cover
+        assume(False)
+    asubindex = set(a[index][Subindex.raw].flat)
+
+    assert asubindex == aE.intersection(aindex)
+
+@given(ellipses(), Tuples, shapes)
+def test_tuple_as_subindex_tuple_hypothesis(idx, index, shape):
+    a = arange(prod(shape)).reshape(shape)
+
+    E = ndindex(idx)
+    try:
+        Index = Tuple(*index)
     except (IndexError, ValueError): # pragma: no cover
         assume(False)
 

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -170,7 +170,7 @@ def test_integer_as_subindex_slice_hypothesis(i, index, size):
 
     try:
         aidx = a[idx]
-    except IndexError:
+    except IndexError: # pragma: no cover
         assume(False)
     aindex = a[index]
     asubindex = aindex[Subindex.raw]
@@ -194,7 +194,7 @@ def test_integer_as_subindex_tuple_hypothesis(i, index, size):
     try:
         aidx = a[idx]
         aindex = a[index]
-    except IndexError:
+    except IndexError: # pragma: no cover
         assume(False)
     asubindex = aindex[Subindex.raw]
 

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -1,4 +1,5 @@
-from numpy import arange, int64
+from numpy import arange, int64, isin
+from numpy.testing import assert_equal
 
 from hypothesis import given, assume
 from hypothesis.strategies import integers
@@ -97,11 +98,11 @@ def test_integer_as_subindex_slice_exhaustive():
                 except NotImplementedError:
                     continue
 
-                aidx = set(a[idx.raw].flat)
-                aindex = set(a[Index.raw].flat)
-                asubindex = set(a[Index.raw][Subindex.raw].flat)
+                aidx = a[idx.raw]
+                aindex = a[Index.raw]
+                asubindex = aindex[Subindex.raw]
 
-                assert asubindex == aidx.intersection(aindex)
+                assert_equal(asubindex, aidx[isin(aidx, aindex)])
 
 # @given(slices(), slices(), integers(0, 100))
 @given(ints(), positive_slices, integers(0, 100))
@@ -119,14 +120,13 @@ def test_integer_as_subindex_slice_hypothesis(i, index, size):
         assume(False)
 
     try:
-        aidx = set(a[idx].flat)
+        aidx = a[idx]
     except IndexError:
         assume(False)
-    aindex = set(a[index].flat)
-    asubindex = set(a[index][Subindex.raw].flat)
+    aindex = a[index]
+    asubindex = aindex[Subindex.raw]
 
-    assert asubindex == aidx.intersection(aindex)
-
+    assert_equal(asubindex, aidx[isin(aidx, aindex)])
 
 @given(ints(), Tuples, integers(0, 100))
 def test_integer_as_subindex_tuple_hypothesis(i, index, size):
@@ -143,10 +143,10 @@ def test_integer_as_subindex_tuple_hypothesis(i, index, size):
         assume(False)
 
     try:
-        aidx = set(a[idx].flat)
-        aindex = set(a[index].flat)
+        aidx = a[idx]
+        aindex = a[index]
     except IndexError:
         assume(False)
-    asubindex = set(a[index][Subindex.raw].flat)
+    asubindex = aindex[Subindex.raw]
 
-    assert asubindex == aidx.intersection(aindex)
+    assert_equal(asubindex, aidx[isin(aidx, aindex)])

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -10,8 +10,7 @@ from ..integer import Integer
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..slice import Slice
-from .helpers import (check_same, ints, prod, shapes, iterslice,
-                      positive_slices, Tuples)
+from .helpers import check_same, ints, prod, shapes, iterslice, slices, Tuples
 
 
 def test_integer_args():
@@ -155,8 +154,7 @@ def test_integer_as_subindex_slice_exhaustive():
 
                 assert_equal(asubindex, aidx[isin(aidx, aindex)])
 
-# @given(slices(), slices(), integers(0, 100))
-@given(ints(), positive_slices, integers(0, 100))
+@given(ints(), slices(), integers(0, 100))
 def test_integer_as_subindex_slice_hypothesis(i, index, size):
     a = arange(size)
     try:

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -5,8 +5,9 @@ from hypothesis.strategies import integers
 
 from ..integer import Integer
 from ..slice import Slice
+from ..tuple import Tuple
 from .helpers import (check_same, ints, prod, shapes, iterslice,
-                      positive_slices)
+                      positive_slices, Tuples)
 
 def test_integer_args():
     zero = Integer(0)
@@ -104,7 +105,7 @@ def test_integer_as_subindex_slice_exhaustive():
 
 # @given(slices(), slices(), integers(0, 100))
 @given(ints(), positive_slices, integers(0, 100))
-def test_slice_as_subindex_slice_hypothesis(i, index, size):
+def test_integer_as_subindex_slice_hypothesis(i, index, size):
     a = arange(size)
     try:
         idx = Integer(i)
@@ -122,6 +123,30 @@ def test_slice_as_subindex_slice_hypothesis(i, index, size):
     except IndexError:
         assume(False)
     aindex = set(a[index].flat)
+    asubindex = set(a[index][Subindex.raw].flat)
+
+    assert asubindex == aidx.intersection(aindex)
+
+
+@given(ints(), Tuples, integers(0, 100))
+def test_integer_as_subindex_tuple_hypothesis(i, index, size):
+    a = arange(size)
+    try:
+        idx = Integer(i)
+        Index = Tuple(*index)
+    except (ValueError, IndexError): # pragma: no cover
+        assume(False)
+
+    try:
+        Subindex = idx.as_subindex(Index)
+    except NotImplementedError: # pragma: no cover
+        assume(False)
+
+    try:
+        aidx = set(a[idx].flat)
+        aindex = set(a[index].flat)
+    except IndexError:
+        assume(False)
     asubindex = set(a[index][Subindex.raw].flat)
 
     assert asubindex == aidx.intersection(aindex)

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -117,7 +117,7 @@ def test_integer_as_subindex_slice_hypothesis(i, index, size):
     try:
         Subindex = idx.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
+        return
 
     try:
         aidx = a[idx]
@@ -140,7 +140,7 @@ def test_integer_as_subindex_tuple_hypothesis(i, index, size):
     try:
         Subindex = idx.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
+        return
 
     try:
         aidx = a[idx]

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -1,6 +1,7 @@
 from pytest import raises
 
-from numpy import arange
+from numpy import arange, isin
+from numpy.testing import assert_equal
 
 from hypothesis import given, assume
 from hypothesis.strategies import integers
@@ -215,13 +216,11 @@ def test_slice_as_subindex_slice_exhaustive():
             except NotImplementedError:
                 continue
 
-            aS = set(a[S.raw].flat)
-            aindex = set(a[Index.raw].flat)
-            asubindex = set(a[Index.raw][Subindex.raw].flat)
+            aS = a[S.raw]
+            aindex = a[Index.raw]
+            asubindex = aindex[Subindex.raw]
 
-            # TODO: This doesn't check that the order of the elements is correct.
-
-            assert asubindex == aS.intersection(aindex)
+            assert_equal(asubindex, aS[isin(aS, aindex)])
 
 # @given(slices(), slices(), integers(0, 100))
 @given(positive_slices, positive_slices, integers(0, 100))
@@ -238,13 +237,12 @@ def test_slice_as_subindex_slice_hypothesis(s, index, size):
     except NotImplementedError: # pragma: no cover
         assume(False)
 
-    aS = set(a[s].flat)
-    aindex = set(a[index].flat)
-    asubindex = set(a[index][Subindex.raw].flat)
 
-    # TODO: This doesn't check that the order of the elements is correct.
+    aS = a[s]
+    aindex = a[index]
+    asubindex = aindex[Subindex.raw]
 
-    assert asubindex == aS.intersection(aindex)
+    assert_equal(asubindex, aS[isin(aS, aindex)])
 
 @given(positive_slices, Tuples, integers(0, 100))
 def test_slice_as_subindex_tuple_hypothesis(s, index, size):
@@ -261,12 +259,10 @@ def test_slice_as_subindex_tuple_hypothesis(s, index, size):
         assume(False)
 
     try:
-        aS = set(a[s].flat)
-        aindex = set(a[index].flat)
+        aS = a[s]
+        aindex = a[index]
     except IndexError: # pgrama: no cover
         assume(False)
-    asubindex = set(a[index][Subindex.raw].flat)
+    asubindex = aindex[Subindex.raw]
 
-    # TODO: This doesn't check that the order of the elements is correct.
-
-    assert asubindex == aS.intersection(aindex)
+    assert_equal(asubindex, aS[isin(aS, aindex)])

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -6,7 +6,7 @@ from hypothesis import given, assume
 from hypothesis.strategies import integers
 
 from ..slice import Slice
-from .helpers import check_same, slices, prod, shapes, iterslice
+from .helpers import check_same, slices, prod, shapes, iterslice, positive_slices
 
 def test_slice_args():
     # Test the behavior when not all three arguments are given
@@ -222,9 +222,6 @@ def test_slice_as_subindex_slice_exhaustive():
                     assert i in asubindex, "%s.as_subindex(%s) == %s" % (S, Index, Subindex)
                 else:
                     assert i not in asubindex, "%s.as_subindex(%s) == %s" % (S, Index, Subindex)
-
-positive_slices = slices(start=integers(0, 10), stop=integers(0, 10),
-                         step=integers(1, 10))
 
 # @given(slices(), slices(), integers(0, 100))
 @given(positive_slices, positive_slices, integers(0, 100))

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -310,7 +310,7 @@ def test_slice_as_subindex_tuple_hypothesis(s, index, size):
     try:
         aS = a[s]
         aindex = a[index]
-    except IndexError: # pgrama: no cover
+    except IndexError: # pragma: no cover
         assume(False)
     asubindex = aindex[Subindex.raw]
 

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -6,7 +6,9 @@ from hypothesis import given, assume
 from hypothesis.strategies import integers
 
 from ..slice import Slice
-from .helpers import check_same, slices, prod, shapes, iterslice, positive_slices
+from ..tuple import Tuple
+from .helpers import (check_same, slices, prod, shapes, iterslice,
+                      positive_slices, Tuples)
 
 def test_slice_args():
     # Test the behavior when not all three arguments are given
@@ -238,6 +240,31 @@ def test_slice_as_subindex_slice_hypothesis(s, index, size):
 
     aS = set(a[s].flat)
     aindex = set(a[index].flat)
+    asubindex = set(a[index][Subindex.raw].flat)
+
+    # TODO: This doesn't check that the order of the elements is correct.
+
+    assert asubindex == aS.intersection(aindex)
+
+@given(positive_slices, Tuples, integers(0, 100))
+def test_slice_as_subindex_tuple_hypothesis(s, index, size):
+    a = arange(size)
+    try:
+        S = Slice(s)
+        Index = Tuple(*index)
+    except (IndexError, ValueError): # pragma: no cover
+        assume(False)
+
+    try:
+        Subindex = S.as_subindex(Index)
+    except NotImplementedError: # pragma: no cover
+        assume(False)
+
+    try:
+        aS = set(a[s].flat)
+        aindex = set(a[index].flat)
+    except IndexError: # pgrama: no cover
+        assume(False)
     asubindex = set(a[index][Subindex.raw].flat)
 
     # TODO: This doesn't check that the order of the elements is correct.

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -9,8 +9,7 @@ from hypothesis.strategies import integers, one_of
 from ..slice import Slice
 from ..tuple import Tuple
 from ..integer import Integer
-from .helpers import (check_same, slices, prod, shapes, iterslice,
-                      positive_slices, Tuples)
+from .helpers import check_same, slices, prod, shapes, iterslice, Tuples
 
 def test_slice_args():
     # Test the behavior when not all three arguments are given
@@ -274,8 +273,7 @@ def test_slice_as_subindex_slice_exhaustive():
 
             assert_equal(asubindex, aS[isin(aS, aindex)])
 
-# @given(slices(), slices(), integers(0, 100))
-@given(positive_slices, positive_slices, integers(0, 100))
+@given(slices(), slices(), integers(0, 100))
 def test_slice_as_subindex_slice_hypothesis(s, index, size):
     a = arange(size)
     try:
@@ -295,7 +293,7 @@ def test_slice_as_subindex_slice_hypothesis(s, index, size):
 
     assert_equal(asubindex, aS[isin(aS, aindex)])
 
-@given(positive_slices, Tuples, integers(0, 100))
+@given(slices(), Tuples, integers(0, 100))
 def test_slice_as_subindex_tuple_hypothesis(s, index, size):
     a = arange(size)
     try:

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -213,15 +213,13 @@ def test_slice_as_subindex_slice_exhaustive():
             except NotImplementedError:
                 continue
 
-            aS = a[S.raw]
-            aindex = a[Index.raw]
-            asubindex = aindex[Subindex.raw]
+            aS = set(a[S.raw].flat)
+            aindex = set(a[Index.raw].flat)
+            asubindex = set(a[Index.raw][Subindex.raw].flat)
 
-            for i in a:
-                if i in aS and i in aindex:
-                    assert i in asubindex, "%s.as_subindex(%s) == %s" % (S, Index, Subindex)
-                else:
-                    assert i not in asubindex, "%s.as_subindex(%s) == %s" % (S, Index, Subindex)
+            # TODO: This doesn't check that the order of the elements is correct.
+
+            assert asubindex == aS.intersection(aindex)
 
 # @given(slices(), slices(), integers(0, 100))
 @given(positive_slices, positive_slices, integers(0, 100))
@@ -238,12 +236,10 @@ def test_slice_as_subindex_slice_hypothesis(s, index, size):
     except NotImplementedError: # pragma: no cover
         assume(False)
 
-    aS = a[s]
-    aindex = a[index]
-    asubindex = aindex[Subindex.raw]
+    aS = set(a[s].flat)
+    aindex = set(a[index].flat)
+    asubindex = set(a[index][Subindex.raw].flat)
 
-    for i in a:
-        if i in aS and i in aindex:
-            assert i in asubindex
-        else:
-            assert i not in asubindex
+    # TODO: This doesn't check that the order of the elements is correct.
+
+    assert asubindex == aS.intersection(aindex)

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -235,8 +235,7 @@ def test_slice_as_subindex_slice_hypothesis(s, index, size):
     try:
         Subindex = S.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
-
+        return
 
     aS = a[s]
     aindex = a[index]
@@ -256,7 +255,7 @@ def test_slice_as_subindex_tuple_hypothesis(s, index, size):
     try:
         Subindex = S.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
+        return
 
     try:
         aS = a[s]

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -187,13 +187,13 @@ def test_ndindex_expand_hypothesis(idx, shape):
             assert len(expanded.args) == len(shape)
 
 
-@given(Tuples, positive_slices, shapes)
+@given(Tuples, Tuples, shapes)
 def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
     a = arange(prod(shape)).reshape(shape)
 
     try:
         T = Tuple(*t)
-        Index = Slice(index)
+        Index = ndindex(index)
     except (IndexError, ValueError): # pragma: no cover
         assume(False)
 

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -8,8 +8,7 @@ from hypothesis.strategies import integers, one_of
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
-from ..slice import Slice
-from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices, positive_slices
+from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices
 
 
 def test_tuple_exhaustive():

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -11,7 +11,7 @@ from pytest import raises
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
-from .helpers import (check_same, Tuples, prod, shapes, iterslice, ndindices, positive_slices)
+from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices, slices
 
 
 def test_tuple_exhaustive():
@@ -219,7 +219,7 @@ def test_tuple_newshape_ndindex_input():
     raises(TypeError, lambda: Tuple(1).newshape(Integer(2)))
 
 
-@given(Tuples, positive_slices, shapes)
+@given(Tuples, slices(), shapes)
 def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
     a = arange(prod(shape)).reshape(shape)
 

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -187,7 +187,7 @@ def test_ndindex_expand_hypothesis(idx, shape):
             assert len(expanded.args) == len(shape)
 
 
-@given(Tuples, Tuples, shapes)
+@given(Tuples, positive_slices, shapes)
 def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
     a = arange(prod(shape)).reshape(shape)
 
@@ -212,4 +212,29 @@ def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
     # TODO: how can we check that the shape is correct?
     assert_equal(asubindex.flatten(), aT[isin(aT, aindex)])
 
+@example((), (slice(None, None, -1),), (2,))
+@example((), (..., slice(None, None, -1),), (2,))
+@given(Tuples, Tuples, shapes)
+def test_tuple_as_subindex_tuple_hypothesis(t, index, shape):
+    a = arange(prod(shape)).reshape(shape)
 
+    try:
+        T = Tuple(*t)
+        Index = ndindex(index)
+    except (IndexError, ValueError): # pragma: no cover
+        assume(False)
+
+    try:
+        Subindex = T.as_subindex(Index)
+    except NotImplementedError: # pragma: no cover
+        return
+
+    try:
+        aT = a[t]
+        aindex = a[index]
+    except IndexError: # pragma: no cover
+        assume(False)
+    asubindex = aindex[Subindex.raw]
+
+    # TODO: how can we check that the shape is correct?
+    assert_equal(asubindex.flatten(), aT[isin(aT, aindex)])

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -203,16 +203,12 @@ def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
         assume(False)
 
     try:
-        aT = a[t]
-        aindex = a[index]
+        aT = set(a[t].flat)
+        aindex = set(a[index].flat)
     except IndexError: # pragma: no cover
         assume(False)
-    asubindex = aindex[Subindex.raw]
+    asubindex = set(a[index][Subindex.raw].flat)
 
-    for i in a.flat:
-        if i in aT and i in aindex:
-            assert i in asubindex
-        else:
-            assert i not in asubindex
+    assert asubindex == aT.intersection(aindex)
 
     # TODO: How can we test that the shape is correct?

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -1,6 +1,7 @@
 from itertools import product
 
-from numpy import arange
+from numpy import arange, isin
+from numpy.testing import assert_equal
 
 from hypothesis import given, assume, example
 from hypothesis.strategies import integers, one_of
@@ -8,7 +9,7 @@ from hypothesis.strategies import integers, one_of
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
-from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices
+from .helpers import (check_same, Tuples, prod, shapes, iterslice, ndindices, positive_slices)
 
 
 def test_tuple_exhaustive():
@@ -202,12 +203,13 @@ def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
         assume(False)
 
     try:
-        aT = set(a[t].flat)
-        aindex = set(a[index].flat)
+        aT = a[t]
+        aindex = a[index]
     except IndexError: # pragma: no cover
         assume(False)
-    asubindex = set(a[index][Subindex.raw].flat)
+    asubindex = aindex[Subindex.raw]
 
-    assert asubindex == aT.intersection(aindex)
+    # TODO: how can we check that the shape is correct?
+    assert_equal(asubindex.flatten(), aT[isin(aT, aindex)])
 
-    # TODO: How can we test that the shape is correct?
+

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -200,7 +200,7 @@ def test_tuple_as_subindex_slice_hypothesis(t, index, shape):
     try:
         Subindex = T.as_subindex(Index)
     except NotImplementedError: # pragma: no cover
-        assume(False)
+        return
 
     try:
         aT = a[t]

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -309,16 +309,21 @@ class Tuple(NDIndex):
         from .ndindex import ndindex
         from .slice import Slice
 
-        index = ndindex(index)
+        index = ndindex(index).reduce()
 
         if isinstance(index, Slice):
             if not self.args:
+                if index.step < 0:
+                    raise NotImplementedError("Tuple.as_subindex() is only implemented on slices with positive steps")
                 return self
 
             first = self.args[0]
             return Tuple(first.as_subindex(index), *self.args[1:])
         elif isinstance(index, Tuple):
             new_args = []
+            if any(isinstance(i, Slice) and i.step < 0 for i in index.args):
+                    raise NotImplementedError("Tuple.as_subindex() is only implemented on slices with positive steps")
+
             for self_arg, index_arg in zip(self.args, index.args):
                 new_args.append(self_arg.as_subindex(index_arg))
             return Tuple(*new_args, *self.args[min(len(self.args), len(index.args)):])

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -304,3 +304,18 @@ class Tuple(NDIndex):
         newargs = newargs + endargs[::-1]
 
         return type(self)(*newargs)
+
+    def as_subindex(self, index):
+        from .ndindex import ndindex
+        from .slice import Slice
+
+        index = ndindex(index)
+
+        if not isinstance(index, Slice):
+            raise NotImplementedError("Tuple.as_subindex is only implemented for slices")
+
+        if not self.args:
+            return self
+
+        first = self.args[0]
+        return Tuple(first.as_subindex(index), *self.args[1:])

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -311,11 +311,16 @@ class Tuple(NDIndex):
 
         index = ndindex(index)
 
-        if not isinstance(index, Slice):
-            raise NotImplementedError("Tuple.as_subindex is only implemented for slices")
+        if isinstance(index, Slice):
+            if not self.args:
+                return self
 
-        if not self.args:
-            return self
-
-        first = self.args[0]
-        return Tuple(first.as_subindex(index), *self.args[1:])
+            first = self.args[0]
+            return Tuple(first.as_subindex(index), *self.args[1:])
+        elif isinstance(index, Tuple):
+            new_args = []
+            for self_arg, index_arg in zip(self.args, index.args):
+                new_args.append(self_arg.as_subindex(index_arg))
+            return Tuple(*new_args, *self.args[min(len(self.args), len(index.args)):])
+        else:
+            raise NotImplementedError("Tuple.as_subindex() is only implemented for slices and tuples")


### PR DESCRIPTION
This implements as_subindex on all types. The argument can now be a Slice or Tuples (as long as the slice is one of the subset of supported slices, and the tuple only contains supported slices). 