### PR TITLE
De-composite helper functions

### DIFF
--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_equal
 from pytest import fail
 
 from hypothesis import assume
-from hypothesis.strategies import integers, composite, none, one_of, lists, just
+from hypothesis.strategies import integers, composite, none, one_of, lists, just, builds
 
 from ..ndindex import ndindex
 
@@ -25,19 +25,16 @@ nonnegative_ints = integers(0, 10)
 negative_ints = integers(-10, -1)
 ints = lambda: one_of(negative_ints, nonnegative_ints)
 
-@composite
-def slices(draw, start=one_of(none(), ints()), stop=one_of(none(), ints()),
+def slices(start=one_of(none(), ints()), stop=one_of(none(), ints()),
            step=one_of(none(), ints())):
-    return slice(draw(start), draw(stop), draw(step))
+    return builds(slice, start, stop, step)
 
 ellipses = lambda: just(...)
 
 # hypotheses.strategies.tuples only generates tuples of a fixed size
-@composite
-def tuples(draw, elements, *, min_size=0, max_size=None, unique_by=None,
-           unique=False):
-    return tuple(draw(lists(elements, min_size=min_size, max_size=max_size,
-                            unique_by=unique_by, unique=unique)))
+def tuples(elements, *, min_size=0, max_size=None, unique_by=None, unique=False):
+    return lists(elements, min_size=min_size, max_size=max_size,
+                 unique_by=unique_by, unique=unique).map(tuple)
 
 Tuples = tuples(one_of(ellipses(), ints(), slices()))
 


### PR DESCRIPTION
Without inter-dependencies between strategies, we can just return a strategy from a function.  This has somewhat better performance because it avoids re-constructing and re-validating strategy objects (even though they're cached).

Loosely related to #46.