### PR TITLE
Update error messages for NumPy 1.19

### DIFF
--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -73,7 +73,7 @@ class Integer(NDIndex):
         if isinstance(shape, int):
             shape = (shape,)
         if len(shape) <= axis:
-            raise IndexError("too many indices for array")
+            raise IndexError(f"too many indices for array: array is {len(shape)}-dimensional, but {axis + 1} were indexed")
 
         size = shape[axis]
         if self.raw >= size or -size > self.raw < 0:

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -306,7 +306,7 @@ class Slice(NDIndex):
         if isinstance(shape, int):
             shape = (shape,)
         if len(shape) <= axis:
-            raise IndexError("too many indices for array")
+            raise IndexError(f"too many indices for array: array is {len(shape)}-dimensional, but {axis + 1} were indexed")
 
         size = shape[axis]
 

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -3,7 +3,7 @@ from pytest import raises
 from numpy import arange, isin
 from numpy.testing import assert_equal
 
-from hypothesis import given, assume
+from hypothesis import given, assume, example
 from hypothesis.strategies import integers, one_of
 
 from ..slice import Slice
@@ -345,6 +345,7 @@ def test_slice_isempty_exhaustive():
 
         assert isempty == aempty, S
 
+@example(slice(None, None, None), ())
 @given(slices(), one_of(shapes, integers(0, 10)))
 def test_slice_isempty_hypothesis(s, shape):
     if isinstance(shape, int):

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -137,7 +137,7 @@ class Tuple(NDIndex):
         >>> idx.reduce((5,))
         Traceback (most recent call last):
         ...
-        IndexError: too many indices for array
+        IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
         >>> idx.reduce((5, 2))
         Traceback (most recent call last):
         ...
@@ -184,9 +184,9 @@ class Tuple(NDIndex):
             shape = (shape,)
 
         if shape is not None:
-            if (self.has_ellipsis and len(shape) < len(self.args) - 1
-                or not self.has_ellipsis and len(shape) < len(self.args)):
-                raise IndexError("too many indices for array")
+            indexed_args = len(self.args) - 1 if self.has_ellipsis else len(self.args)
+            if len(shape) < indexed_args:
+                raise IndexError(f"too many indices for array: array is {len(shape)}-dimensional, but {indexed_args} were indexed")
 
         ellipsis_i = self.ellipsis_index
 
@@ -261,7 +261,7 @@ class Tuple(NDIndex):
         >>> idx.expand((5,))
         Traceback (most recent call last):
         ...
-        IndexError: too many indices for array
+        IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
         >>> idx.expand((5, 2))
         Traceback (most recent call last):
         ...
@@ -284,9 +284,9 @@ class Tuple(NDIndex):
         if isinstance(shape, int):
             shape = (shape,)
 
-        if (self.has_ellipsis and len(shape) < len(self.args) - 1
-            or not self.has_ellipsis and len(shape) < len(self.args)):
-            raise IndexError("too many indices for array")
+        indexed_args = len(self.args) - 1 if self.has_ellipsis else len(self.args)
+        if len(shape) < indexed_args:
+            raise IndexError(f"too many indices for array: array is {len(shape)}-dimensional, but {indexed_args} were indexed")
 
         ellipsis_i = self.ellipsis_index
 


### PR DESCRIPTION
For now I only intend to support the latest NumPy version. Actually ndindex
will still work just fine with older versions, but the tests will fail because
they check that the error messages are the same as what NumPy gives.