### PR TITLE
Factor out shape canonicalization into a helper function

### DIFF
--- a/ndindex/ellipsis.py
+++ b/ndindex/ellipsis.py
@@ -1,4 +1,4 @@
-from .ndindex import NDIndex
+from .ndindex import NDIndex, asshape
 from .tuple import Tuple
 
 class ellipsis(NDIndex):
@@ -75,8 +75,7 @@ class ellipsis(NDIndex):
         if isinstance(shape, (Tuple, Integer)):
             raise TypeError("ndindex types are not meant to be used as a shape - "
                             "did you mean to use the built-in tuple type?")
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
 
         return shape
 

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -1,6 +1,6 @@
 import operator
 
-from .ndindex import NDIndex
+from .ndindex import NDIndex, asshape
 
 class Integer(NDIndex):
     """
@@ -70,8 +70,7 @@ class Integer(NDIndex):
         if shape is None:
             return self
 
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
         if len(shape) <= axis:
             raise IndexError("too many indices for array")
 
@@ -91,8 +90,7 @@ class Integer(NDIndex):
         if isinstance(shape, (Tuple, Integer)):
             raise TypeError("ndindex types are not meant to be used as a shape - "
                             "did you mean to use the built-in tuple type?")
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
 
         # reduce will raise IndexError if it should be raised
         self.reduce(shape)
@@ -121,8 +119,7 @@ class Integer(NDIndex):
 
     def isempty(self, shape=None):
         if shape is not None:
-            if isinstance(shape, int):
-                shape = (shape,)
+            shape = asshape(shape)
             # Raise IndexError if necessary
             self.reduce(shape)
             if 0 in shape:

--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -1,4 +1,6 @@
 import inspect
+import operator
+import numbers
 
 from numpy import ndarray
 
@@ -336,3 +338,39 @@ class NDIndex:
 
         """
         raise NotImplementedError
+
+def asshape(shape):
+    """
+    Cast `shape` as a valid NumPy shape.
+
+    The input can be an integer `n`, which is equivalent to `(n,)`, or a tuple
+    of integers.
+
+    The resulting shape is always a tuple of nonnegative integers.
+
+    All ndindex code that takes a shape should use
+
+        shape = asindex(shape)
+
+    """
+    if isinstance(shape, numbers.Number):
+        shape = (operator.index(shape),)
+
+    try:
+        l = len(shape)
+        if l < 0:
+            raise TypeError
+    except TypeError:
+        raise TypeError("expected sequence object with len >= 0 or a single integer")
+
+    newshape = []
+    # numpy uses __getitem__ rather than __iter__ to index into shape, so we
+    # match that
+    for i in range(l):
+        # Raise TypeError if invalid
+        newshape.append(operator.index(shape[i]))
+
+        if shape[i] < 0:
+            raise ValueError("unknown (negative) dimensions are not supported")
+
+    return tuple(newshape)

--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -358,8 +358,6 @@ def asshape(shape):
 
     try:
         l = len(shape)
-        if l < 0:
-            raise TypeError
     except TypeError:
         raise TypeError("expected sequence object with len >= 0 or a single integer")
 

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -4,7 +4,7 @@ import math
 from sympy.ntheory.modular import crt
 from sympy import ilcm
 
-from .ndindex import NDIndex
+from .ndindex import NDIndex, asshape
 
 class default:
     """
@@ -303,8 +303,7 @@ class Slice(NDIndex):
 
         # Further canonicalize with an explicit array shape
 
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
         if len(shape) <= axis:
             raise IndexError("too many indices for array")
 
@@ -357,8 +356,7 @@ class Slice(NDIndex):
         if isinstance(shape, (Tuple, Integer)):
             raise TypeError("ndindex types are not meant to be used as a shape - "
                             "did you mean to use the built-in tuple type?")
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
 
         idx = self.reduce(shape)
 
@@ -430,8 +428,7 @@ class Slice(NDIndex):
     def isempty(self, shape=None):
         idx = self
         if shape is not None:
-            if isinstance(shape, int):
-                shape = (shape,)
+            shape = asshape(shape)
             if 0 in shape:
                 return True
             idx = self.reduce(shape)

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -61,9 +61,3 @@ def test_asshape():
     raises(TypeError, lambda: asshape((1.0,)))
     raises(ValueError, lambda: asshape(-1))
     raises(ValueError, lambda: asshape((1, -1)))
-
-    class NegativeLen:
-        def __len__(self):
-            return -1
-
-    raises(TypeError, lambda: asshape(NegativeLen()))

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -61,3 +61,4 @@ def test_asshape():
     raises(TypeError, lambda: asshape((1.0,)))
     raises(ValueError, lambda: asshape(-1))
     raises(ValueError, lambda: asshape((1, -1)))
+    raises(TypeError, lambda: asshape(...))

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -1,10 +1,12 @@
 import inspect
 
+import numpy as np
+
 from hypothesis import given, example
 
 from pytest import raises
 
-from ..ndindex import ndindex
+from ..ndindex import ndindex, asshape
 from ..integer import Integer
 from ..ellipsis import ellipsis
 from .helpers import ndindices
@@ -44,3 +46,18 @@ def test_str(idx):
     d = {}
     exec("from ndindex import *", d)
     assert eval(str(index), d) == idx
+
+def test_asshape():
+    assert asshape(1) == (1,)
+    assert asshape(np.int64(2)) == (2,)
+    assert type(asshape(np.int64(2))[0]) == int
+    assert asshape((1, 2)) == (1, 2)
+    assert asshape([1, 2]) == (1, 2)
+    assert asshape((np.int64(1), np.int64(2))) == (1, 2)
+    assert type(asshape((np.int64(1), np.int64(2)))[0]) == int
+    assert type(asshape((np.int64(1), np.int64(2)))[1]) == int
+
+    raises(TypeError, lambda: asshape(1.0))
+    raises(TypeError, lambda: asshape((1.0,)))
+    raises(ValueError, lambda: asshape(-1))
+    raises(ValueError, lambda: asshape((1, -1)))

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -61,3 +61,9 @@ def test_asshape():
     raises(TypeError, lambda: asshape((1.0,)))
     raises(ValueError, lambda: asshape(-1))
     raises(ValueError, lambda: asshape((1, -1)))
+
+    class NegativeLen:
+        def __len__(self):
+            return -1
+
+    raises(TypeError, lambda: asshape(NegativeLen()))

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -277,6 +277,7 @@ def test_slice_as_subindex_slice_exhaustive():
 
             assert_equal(asubindex, aS[isin(aS, aindex)])
 
+@example(slice(0, 10), slice(5, 15), 20)
 @given(slices(), slices(), integers(0, 100))
 def test_slice_as_subindex_slice_hypothesis(s, index, size):
     a = arange(size)

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import integers, one_of
 
 from pytest import raises
 
-from ..ndindex import ndindex, asshape
+from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
 from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices, slices

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import integers, one_of
 
 from pytest import raises
 
-from ..ndindex import ndindex
+from ..ndindex import ndindex, asshape
 from ..tuple import Tuple
 from ..integer import Integer
 from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices, slices

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -1,4 +1,4 @@
-from .ndindex import NDIndex, ndindex
+from .ndindex import NDIndex, ndindex, asshape
 
 class Tuple(NDIndex):
     """
@@ -180,8 +180,7 @@ class Tuple(NDIndex):
         if ellipsis() not in args:
             return type(self)(*args, ellipsis()).reduce(shape)
 
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
 
         if shape is not None:
             if (self.has_ellipsis and len(shape) < len(self.args) - 1
@@ -281,8 +280,7 @@ class Tuple(NDIndex):
         if ellipsis() not in args:
             return type(self)(*args, ellipsis()).expand(shape)
 
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
 
         if (self.has_ellipsis and len(shape) < len(self.args) - 1
             or not self.has_ellipsis and len(shape) < len(self.args)):
@@ -313,8 +311,7 @@ class Tuple(NDIndex):
         if isinstance(shape, (Tuple, Integer)):
             raise TypeError("ndindex types are not meant to be used as a shape - "
                             "did you mean to use the built-in tuple type?")
-        if isinstance(shape, int):
-            shape = (shape,)
+        shape = asshape(shape)
 
         if self == Tuple():
             return shape
@@ -369,8 +366,7 @@ class Tuple(NDIndex):
     def isempty(self, shape=None):
         idx = self
         if shape is not None:
-            if isinstance(shape, int):
-                shape = (shape,)
+            shape = asshape(shape)
             if 0 in shape:
                 return True
             idx = self.reduce(shape)

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -180,9 +180,8 @@ class Tuple(NDIndex):
         if ellipsis() not in args:
             return type(self)(*args, ellipsis()).reduce(shape)
 
-        shape = asshape(shape)
-
         if shape is not None:
+            shape = asshape(shape)
             if (self.has_ellipsis and len(shape) < len(self.args) - 1
                 or not self.has_ellipsis and len(shape) < len(self.args)):
                 raise IndexError("too many indices for array")


### PR DESCRIPTION
This also adds support for NumPy integers as shape terms, and does better type
checking on shape arguments.