### PR TITLE
Make ndindex() match exceptions from NumPy

### DIFF
--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -1,12 +1,16 @@
 import inspect
 import operator
 import numbers
+import warnings
 
-from numpy import ndarray
+from numpy import ndarray, asarray, integer, bool_, int64
 
 def ndindex(obj):
     """
     Convert an object into an ndindex type
+
+    Invalid indices will raise IndexError. Indices that are supported by NumPy
+    but not yet supported by ndindex will raise NotImplementedError.
 
     >>> from ndindex import ndindex
     >>> ndindex(1)
@@ -23,7 +27,23 @@ def ndindex(obj):
         raise NotImplementedError("newaxis is not yet implemented")
 
     if isinstance(obj, (list, ndarray, bool)):
-        raise NotImplementedError("array indices are not yet supported")
+        # Ignore deprecation warnings for things like [1, []]. These will be
+        # filtered out anyway since they produce object arrays.
+        with warnings.catch_warnings(record=True):
+            if isinstance(obj, list) and obj == []:
+                a = asarray([], dtype=int64)
+            else:
+                a = asarray(obj)
+        if issubclass(a.dtype.type, integer):
+            raise NotImplementedError("integer array indices are not yet supported")
+        elif a.dtype == bool_:
+            raise NotImplementedError("boolean array indices are not yet supported")
+        else:
+            # Match the NumPy exceptions
+            if isinstance(obj, ndarray):
+                raise IndexError("arrays used as indices must be of integer (or boolean) type")
+            else:
+                raise IndexError("only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices")
 
     try:
         # If operator.index() works, use that
@@ -38,11 +58,11 @@ def ndindex(obj):
         return Tuple(*obj)
 
     if obj == ellipsis:
-        raise TypeError("Got ellipsis class. Did you mean to use the instance, ellipsis()?")
+        raise IndexError("Got ellipsis class. Did you mean to use the instance, ellipsis()?")
     if obj is Ellipsis:
         return ellipsis()
 
-    raise TypeError(f"Don't know how to convert object of type {type(obj)} to an ndindex object")
+    raise IndexError("only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices")
 
 class classproperty(object):
     def __init__(self, f):
@@ -118,7 +138,7 @@ class NDIndex:
         if not isinstance(other, NDIndex):
             try:
                 other = ndindex(other)
-            except (TypeError, NotImplementedError):
+            except (IndexError, NotImplementedError):
                 return False
 
         return ((isinstance(other, self.__class__)

--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -3,7 +3,7 @@ import operator
 import numbers
 import warnings
 
-from numpy import ndarray, asarray, integer, bool_, int64
+from numpy import ndarray, asarray, integer, bool_, intp
 
 def ndindex(obj):
     """
@@ -31,7 +31,7 @@ def ndindex(obj):
         # filtered out anyway since they produce object arrays.
         with warnings.catch_warnings(record=True):
             if isinstance(obj, list) and obj == []:
-                a = asarray([], dtype=int64)
+                a = asarray([], dtype=intp)
             else:
                 a = asarray(obj)
         if issubclass(a.dtype.type, integer):


### PR DESCRIPTION
It will always raise IndexError or NotImplementedError. Previously it would
raise TypeError. The error messages also match NumPy's.

This also more accurately tests array types to see if they are integer or
boolean arrays.