### PR TITLE
Implement Tuples of array indices

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,3 +89,5 @@ These classes are only intended for internal use in ndindex.
 .. autoclass:: ndindex.slice.default
 
 .. autofunction:: ndindex.ndindex.asshape
+
+.. autofunction:: ndindex.ndindex.operator_index

--- a/docs/type-confusion.md
+++ b/docs/type-confusion.md
@@ -208,7 +208,10 @@ Additionally, some advice for specific types:
 
 - `ellipsis` is **not** singletonized, unlike the built-in `...`. It would
   also be impossible to make `ellipsis() is ...` return True. If you are using
-  ndindex, **you should use `==` to compare against `...`**, and avoid using `is`.
+  ndindex, **you should use `==` to compare against `...`**, and avoid using
+  `is`. Note that as long as you know `idx` is an ndindex type, this is safe
+  to do, since even the array index types `IntegerArray` and `BooleanArray`
+  allow `==` comparison (unlike NumPy arrays).
 
   **Right:**
 
@@ -278,7 +281,10 @@ Note that `np.newaxis` is just an alias for `None`.
 - `Newaxis` is **not** singletonized, unlike the built-in `None`. It would
   also be impossible to make `Newaxis() is np.newaxis` or `Newaxis() is None`
   return True. If you are using ndindex, **you should use `==` to compare
-  against `np.newaxis` or `None`**, and avoid using `is`.
+  against `np.newaxis` or `None`**, and avoid using `is`. Note that as long as
+  you know `idx` is an ndindex type, this is safe to do, since even the array
+  index types `IntegerArray` and `BooleanArray` allow `==` comparison (unlike
+  NumPy arrays).
 
   **Right:**
 

--- a/ndindex/array.py
+++ b/ndindex/array.py
@@ -103,6 +103,24 @@ class ArrayIndex(NDIndex):
         """
         return self.array.ndim
 
+    @property
+    def size(self):
+        """
+        Return the number of elements of the array of self.
+
+        This is the same as `self.array.size`. Note that this is **not** the
+        same as the number of elements of an array that is indexed by `self`.
+        Use `np.prod` on :meth:`~.NDIndex.newshape` to get that.
+
+        >>> from ndindex import IntegerArray, BooleanArray
+        >>> IntegerArray([[0], [1]]).size
+        2
+        >>> BooleanArray([[False], [True]]).size
+        2
+
+        """
+        return self.array.size
+
     # The repr form recreates the object. The str form gives the truncated
     # array string and is explicitly non-valid Python (doesn't have commas).
     def __repr__(self):

--- a/ndindex/array.py
+++ b/ndindex/array.py
@@ -37,9 +37,13 @@ class ArrayIndex(NDIndex):
                 if a is idx and _copy:
                     a = a.copy()
                 if isinstance(idx, list) and 0 in a.shape:
+                    if not _copy:
+                        raise ValueError("_copy=False is not allowed with list input")
                     a = a.astype(self.dtype)
             if self.dtype == intp and issubclass(a.dtype.type, integer):
                 if a.dtype != self.dtype:
+                    if not _copy:
+                        raise ValueError("If _copy=False, the input array dtype must already be intp")
                     a = a.astype(self.dtype)
             if a.dtype != self.dtype:
                 raise TypeError(f"The input array to {self.__class__.__name__} must have dtype {self.dtype.__name__}, not {a.dtype}")

--- a/ndindex/array.py
+++ b/ndindex/array.py
@@ -17,7 +17,7 @@ class ArrayIndex(NDIndex):
     # Subclasses should redefine this
     dtype = None
 
-    def _typecheck(self, idx, shape=None):
+    def _typecheck(self, idx, shape=None, _copy=True):
         if self.dtype is None:
             raise TypeError("Do not instantiate the superclass ArrayIndex directly")
 
@@ -34,7 +34,7 @@ class ArrayIndex(NDIndex):
             # filtered out anyway since they produce object arrays.
             with warnings.catch_warnings(record=True):
                 a = asarray(idx)
-                if a is idx:
+                if a is idx and _copy:
                     a = a.copy()
                 if isinstance(idx, list) and 0 in a.shape:
                     a = a.astype(self.dtype)

--- a/ndindex/booleanarray.py
+++ b/ndindex/booleanarray.py
@@ -26,7 +26,7 @@ class BooleanArray(ArrayIndex):
        and replace them with a single flat dimension which is the size of the
        number of `True` elements in the index.
 
-    2. A boolean array index `idx` works the same as the integer index
+    2. A boolean array index `idx` works the same as the integer array index
        `np.nonzero(idx)`. In particular, the elements of the index are always
        iterated in row-major, C-style order. This does not apply to
        0-dimensional boolean indices.

--- a/ndindex/booleanarray.py
+++ b/ndindex/booleanarray.py
@@ -137,15 +137,11 @@ class BooleanArray(ArrayIndex):
 
         return self
 
-    def newshape(self, shape, _axis=None):
+    def newshape(self, shape):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        if _axis is not None:
-            # reduce will raise IndexError if it should be raised
-            self.reduce(shape, axis=_axis)
-            return (self.count_nonzero,)
-
+        # reduce will raise IndexError if it should be raised
         self.reduce(shape)
         return (self.count_nonzero,) + shape[self.ndim:]
 

--- a/ndindex/booleanarray.py
+++ b/ndindex/booleanarray.py
@@ -137,13 +137,16 @@ class BooleanArray(ArrayIndex):
 
         return self
 
-    def newshape(self, shape):
+    def newshape(self, shape, _axis=None):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        # reduce will raise IndexError if it should be raised
-        self.reduce(shape)
+        if _axis is not None:
+            # reduce will raise IndexError if it should be raised
+            self.reduce(shape, axis=_axis)
+            return (self.count_nonzero,)
 
+        self.reduce(shape)
         return (self.count_nonzero,) + shape[self.ndim:]
 
     def isempty(self, shape=None):

--- a/ndindex/booleanarray.py
+++ b/ndindex/booleanarray.py
@@ -11,7 +11,9 @@ class BooleanArray(ArrayIndex):
     and `a` is an array of shape `s = (s1, ..., sn, ..., sm)`, `a[idx]`
     replaces the first `n` dimensions of `a` with a single dimensions of size
     `np.nonzero(idx)`, where each entry is included if the corresponding
-    element of `idx` is True.
+    element of `idx` is True. The axes in the index shape should match the
+    corresponding axes in the array shape or be 0, or the index produces
+    IndexError.
 
     The typical way of creating a mask is to use boolean operations on an
     array, then index the array with that. For example, if `a` is an array of
@@ -29,7 +31,7 @@ class BooleanArray(ArrayIndex):
        iterated in row-major, C-style order. This does not apply to
        0-dimensional boolean indices.
 
-    3. A 0-dimension boolean index (i.e., just the scalar `True` or `False`)
+    3. A 0-dimensional boolean index (i.e., just the scalar `True` or `False`)
        can still be thought of as removing 0 dimensions and adding a single
        dimension of length 1 for True or 0 for False. Hence, if `a` has shape
        `(s1, ..., sn)`, then `a[True]` has shape `(1, s1, ..., sn)`, and
@@ -129,7 +131,8 @@ class BooleanArray(ArrayIndex):
             raise IndexError(f"too many indices for array: array is {len(shape)}-dimensional, but {self.ndim + axis} were indexed")
 
         for i in range(axis, axis+self.ndim):
-            if self.shape[i-axis] != 0 and shape[i] != 0 and 0 not in shape and shape[i] != self.shape[i-axis]:
+            if self.shape[i-axis] != 0 and shape[i] != self.shape[i-axis]:
+
                 raise IndexError(f"boolean index did not match indexed array along dimension {i}; dimension is {shape[i]} but corresponding boolean dimension is {self.shape[i-axis]}")
 
         return self

--- a/ndindex/ellipsis.py
+++ b/ndindex/ellipsis.py
@@ -75,9 +75,12 @@ class ellipsis(NDIndex):
     def raw(self):
         return ...
 
-    def newshape(self, shape):
+    def newshape(self, shape, _axis=None):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
+
+        if _axis is not None:
+            return shape[_axis]
 
         return shape
 

--- a/ndindex/ellipsis.py
+++ b/ndindex/ellipsis.py
@@ -75,12 +75,9 @@ class ellipsis(NDIndex):
     def raw(self):
         return ...
 
-    def newshape(self, shape, _axis=None):
+    def newshape(self, shape):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
-
-        if _axis is not None:
-            return shape[_axis]
 
         return shape
 

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -87,13 +87,16 @@ class Integer(NDIndex):
 
         return self
 
-    def newshape(self, shape):
+    def newshape(self, shape, _axis=None):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        # reduce will raise IndexError if it should be raised
-        self.reduce(shape)
+        if _axis is not None:
+            # reduce will raise IndexError if it should be raised
+            self.reduce(shape, axis=_axis)
+            return ()
 
+        self.reduce(shape)
         return shape[1:]
 
     def as_subindex(self, index):

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -1,6 +1,4 @@
-import operator
-
-from .ndindex import NDIndex, asshape
+from .ndindex import NDIndex, asshape, operator_index
 
 class Integer(NDIndex):
     """
@@ -29,8 +27,7 @@ class Integer(NDIndex):
 
     """
     def _typecheck(self, idx):
-        idx = operator.index(idx)
-
+        idx = operator_index(idx)
         return (idx,)
 
     def __index__(self):

--- a/ndindex/integer.py
+++ b/ndindex/integer.py
@@ -87,15 +87,11 @@ class Integer(NDIndex):
 
         return self
 
-    def newshape(self, shape, _axis=None):
+    def newshape(self, shape):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        if _axis is not None:
-            # reduce will raise IndexError if it should be raised
-            self.reduce(shape, axis=_axis)
-            return ()
-
+        # reduce will raise IndexError if it should be raised
         self.reduce(shape)
         return shape[1:]
 

--- a/ndindex/integerarray.py
+++ b/ndindex/integerarray.py
@@ -48,8 +48,9 @@ class IntegerArray(ArrayIndex):
         Reduce an `IntegerArray` index on an array of shape `shape`.
 
         The result will either be `IndexError` if the index is invalid for the
-        given shape, or an `IntegerArray` index where the values are all
-        nonnegative.
+        given shape, an `IntegerArray` index where the values are all
+        nonnegative, or, if `self` is a scalar array index (`self.shape ==
+        ()`), an `Integer` whose value is nonnegative.
 
         >>> from ndindex import IntegerArray
         >>> idx = IntegerArray([-5, 2])

--- a/ndindex/integerarray.py
+++ b/ndindex/integerarray.py
@@ -14,7 +14,11 @@ class IntegerArray(ArrayIndex):
 
     Integer arrays can also appear as part of tuple indices. In that case,
     they replace the axis being indexed. If more than one integer array
-    appears inside of a tuple index, they are broadcast together.
+    appears inside of a tuple index, they are broadcast together and iterated
+    as one. Furthermore, if an integer array appears in a tuple index, all
+    integer indices in the tuple are treated as scalar integer arrays and are
+    also broadcast. In general, an :any:`Integer` index semantically behaves
+    the same as a scalar (`shape=()`) `IntegerArray`.
 
     A list of integers may also be used in place of an integer array. Note
     that NumPy treats a direct list of integers as a tuple index, but this

--- a/ndindex/integerarray.py
+++ b/ndindex/integerarray.py
@@ -1,4 +1,4 @@
-from numpy import intp, zeros
+from numpy import intp
 
 from .array import ArrayIndex
 from .ndindex import asshape
@@ -86,16 +86,6 @@ class IntegerArray(ArrayIndex):
             return self
 
         shape = asshape(shape, axis=axis)
-        if 0 in shape[:axis] + shape[axis+1:]:
-            # There are no bounds checks for empty arrays if one of the
-            # non-indexed axes is 0. This behavior will be deprecated in NumPy
-            # 1.20. Once 1.20 is released, we will change the ndindex behavior
-            # to match it, since we want to match all post-deprecation NumPy
-            # behavior. But it is impossible to test against the
-            # post-deprecation behavior reliably until a version of NumPy is
-            # released that raises the deprecation warning, so for now, we
-            # just match the NumPy 1.19 behavior.
-            return IntegerArray(zeros(self.shape, dtype=intp))
 
         size = shape[axis]
         new_array = self.array.copy()
@@ -106,20 +96,11 @@ class IntegerArray(ArrayIndex):
         new_array[new_array < 0] += size
         return IntegerArray(new_array)
 
-    def newshape(self, shape, _axis=None):
+    def newshape(self, shape):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        # We need to split out the axis argument so that we can match the
-        # NumPy 1.19 behavior for out of bounds integer array indices on empty
-        # arrays (see the comment in IntegerArray.reduce()). Once we move to
-        # NumPy 1.20 post-deprecation semantics, we can remove this argument
-        # from the newshape() methods.
-        if _axis is not None:
-            # reduce will raise IndexError if it should be raised
-            self.reduce(shape, axis=_axis)
-            return self.shape
-
+        # reduce will raise IndexError if it should be raised
         self.reduce(shape)
         return self.shape + shape[1:]
 

--- a/ndindex/integerarray.py
+++ b/ndindex/integerarray.py
@@ -106,13 +106,21 @@ class IntegerArray(ArrayIndex):
         new_array[new_array < 0] += size
         return IntegerArray(new_array)
 
-    def newshape(self, shape):
+    def newshape(self, shape, _axis=None):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        # reduce will raise IndexError if it should be raised
-        self.reduce(shape)
+        # We need to split out the axis argument so that we can match the
+        # NumPy 1.19 behavior for out of bounds integer array indices on empty
+        # arrays (see the comment in IntegerArray.reduce()). Once we move to
+        # NumPy 1.20 post-deprecation semantics, we can remove this argument
+        # from the newshape() methods.
+        if _axis is not None:
+            # reduce will raise IndexError if it should be raised
+            self.reduce(shape, axis=_axis)
+            return self.shape
 
+        self.reduce(shape)
         return self.shape + shape[1:]
 
     def isempty(self, shape=None):

--- a/ndindex/ndindex.py
+++ b/ndindex/ndindex.py
@@ -1,9 +1,8 @@
 import inspect
 import operator
 import numbers
-import warnings
 
-from numpy import ndarray, asarray, integer, bool_, intp
+from numpy import ndarray, bool_
 
 def ndindex(obj):
     """
@@ -27,25 +26,21 @@ def ndindex(obj):
     if obj is None:
         raise NotImplementedError("newaxis is not yet implemented")
 
-    # TODO: Replace this with calls to the IntegerArray() and BooleanArray()
-    # constructors.
-    if isinstance(obj, (list, ndarray, bool)):
-        # Ignore deprecation warnings for things like [1, []]. These will be
-        # filtered out anyway since they produce object arrays.
-        with warnings.catch_warnings(record=True):
-            a = asarray(obj)
-            if isinstance(obj, list) and 0 in a.shape:
-                a = a.astype(intp)
-        if issubclass(a.dtype.type, integer):
-            return IntegerArray(a)
-        elif a.dtype == bool_:
-            return BooleanArray(a)
+    if isinstance(obj, (list, ndarray, bool, bool_)):
+        try:
+            return IntegerArray(obj)
+        except TypeError:
+            pass
+        try:
+            return BooleanArray(obj)
+        except TypeError:
+            pass
+
+        # Match the NumPy exceptions
+        if isinstance(obj, ndarray):
+            raise IndexError("arrays used as indices must be of integer (or boolean) type")
         else:
-            # Match the NumPy exceptions
-            if isinstance(obj, ndarray):
-                raise IndexError("arrays used as indices must be of integer (or boolean) type")
-            else:
-                raise IndexError("only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices")
+            raise IndexError("only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices")
 
     try:
         # If operator.index() works, use that

--- a/ndindex/newaxis.py
+++ b/ndindex/newaxis.py
@@ -67,9 +67,13 @@ class Newaxis(NDIndex):
             shape = asshape(shape)
         return self
 
-    def newshape(self, shape):
+    def newshape(self, shape, _axis=None):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
+
+        if _axis is not None:
+            self.reduce(shape, axis=_axis)
+            return (1,)
 
         # reduce will raise IndexError if it should be raised
         self.reduce(shape)

--- a/ndindex/newaxis.py
+++ b/ndindex/newaxis.py
@@ -67,13 +67,9 @@ class Newaxis(NDIndex):
             shape = asshape(shape)
         return self
 
-    def newshape(self, shape, _axis=None):
+    def newshape(self, shape):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
-
-        if _axis is not None:
-            self.reduce(shape, axis=_axis)
-            return (1,)
 
         # reduce will raise IndexError if it should be raised
         self.reduce(shape)

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -346,13 +346,18 @@ class Slice(NDIndex):
                 stop += size
         return self.__class__(start, stop, step)
 
-    def newshape(self, shape):
+    def newshape(self, shape, _axis=None):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
+        if _axis is not None:
+            idx = self.reduce(shape, axis=_axis)
+
+            # len() won't raise an error after reducing with a shape
+            return (len(idx),)
+
         idx = self.reduce(shape)
 
-        # len() won't raise an error after reducing with a shape
         return (len(idx),) + shape[1:]
 
     # TODO: Better name?

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -346,18 +346,13 @@ class Slice(NDIndex):
                 stop += size
         return self.__class__(start, stop, step)
 
-    def newshape(self, shape, _axis=None):
+    def newshape(self, shape):
         # The docstring for this method is on the NDIndex base class
         shape = asshape(shape)
 
-        if _axis is not None:
-            idx = self.reduce(shape, axis=_axis)
-
-            # len() won't raise an error after reducing with a shape
-            return (len(idx),)
-
         idx = self.reduce(shape)
 
+        # len() won't raise an error after reducing with a shape
         return (len(idx),) + shape[1:]
 
     # TODO: Better name?

--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -1,9 +1,7 @@
-import operator
-
 from sympy.ntheory.modular import crt
 from sympy import ilcm, Rational
 
-from .ndindex import NDIndex, asshape
+from .ndindex import NDIndex, asshape, operator_index
 
 class default:
     """
@@ -65,11 +63,11 @@ class Slice(NDIndex):
             raise ValueError("slice step cannot be zero")
 
         if start is not None:
-            start = operator.index(start)
+            start = operator_index(start)
         if stop is not None:
-            stop = operator.index(stop)
+            stop = operator_index(stop)
         if step is not None:
-            step = operator.index(step)
+            step = operator_index(step)
 
         args = (start, stop, step)
 

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -52,10 +52,12 @@ short_shapes = tuples(integers(0, 10)).filter(
              lambda shape: prod([i for i in shape if i]) < 1000)
 
 _integer_arrays = arrays(intp, short_shapes)
-integer_arrays = _integer_arrays.flatmap(lambda x: one_of(just(x), just(x.tolist())))
+integer_scalars = arrays(intp, ()).map(lambda x: x[()])
+integer_arrays = one_of(integer_scalars, _integer_arrays.flatmap(lambda x: one_of(just(x), just(x.tolist()))))
 
 _boolean_arrays = arrays(bool_, shapes)
-boolean_arrays = _boolean_arrays.flatmap(lambda x: one_of(just(x), just(x.tolist())))
+boolean_scalars = arrays(bool_, ()).map(lambda x: x[()])
+boolean_arrays = one_of(boolean_scalars, _boolean_arrays.flatmap(lambda x: one_of(just(x), just(x.tolist()))))
 
 def _doesnt_raise(idx):
     try:

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -46,7 +46,12 @@ shapes = tuples(integers(0, 10)).filter(
              # See https://github.com/numpy/numpy/issues/15753
              lambda shape: prod([i for i in shape if i]) < 100000)
 
-_integer_arrays = arrays(intp, shapes)
+short_shapes = tuples(integers(0, 10)).filter(
+             # numpy gives errors with empty arrays with large shapes.
+             # See https://github.com/numpy/numpy/issues/15753
+             lambda shape: prod([i for i in shape if i]) < 1000)
+
+_integer_arrays = arrays(intp, short_shapes)
 integer_arrays = _integer_arrays.flatmap(lambda x: one_of(just(x), just(x.tolist())))
 
 _boolean_arrays = arrays(bool_, shapes)

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -126,7 +126,7 @@ def check_same(a, idx, raw_func=lambda a, idx: a[idx],
                 if ("Using a non-tuple sequence for multidimensional indexing is deprecated" in w.args[0]):
                     idx = array(idx)
                     a_raw = raw_func(a, idx)
-                else:
+                else: # pragma: no cover
                     fail(f"Unexpected warning raised: {w}")
         except Exception:
             _, e_inner, _ = sys.exc_info()

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -2,7 +2,6 @@ import sys
 from itertools import chain
 from functools import reduce
 from operator import mul
-import warnings
 
 from numpy import intp, bool_, array
 import numpy.testing

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -122,25 +122,18 @@ def check_same(a, idx, raw_func=lambda a, idx: a[idx],
         try:
             try:
                 a_raw = raw_func(a, idx)
-            except FutureWarning as w:
+            except Warning as w:
                 if ("Using a non-tuple sequence for multidimensional indexing is deprecated" in w.args[0]):
                     idx = array(idx)
                     a_raw = raw_func(a, idx)
+                elif "Out of bound index found. This was previously ignored when the indexing result contained no elements. In the future the index error will be raised. This error occurs either due to an empty slice, or if an array has zero elements even before indexing." in w.args[0]:
+                    same_exception = False
+                    raise IndexError
                 else: # pragma: no cover
                     fail(f"Unexpected warning raised: {w}")
         except Exception:
             _, e_inner, _ = sys.exc_info()
         if e_inner:
-            if (isinstance(e_inner, ValueError)
-                and (e_inner.args[0].startswith('operands could not be broadcast together with shapes')
-                     or e_inner.args[0].startswith('non-broadcastable operand with shape'))):
-                # NumPy has a bug where it sometimes gives
-                # ValueError('operands could not be broadcast together with
-                # shapes ...') instead of the correct IndexError (see
-                # https://github.com/numpy/numpy/issues/16997). We don't want
-                # to reproduce this incorrect error, so ignore it.
-                same_exception = False
-                raise IndexError
             raise e_inner
     except Exception as e:
         exception = e

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -65,7 +65,7 @@ def _doesnt_raise(idx):
         return False
     return True
 
-Tuples = tuples(one_of(ellipses(), newaxes(), ints(), slices(),
+Tuples = tuples(one_of(ellipses(), ints(), slices(), newaxes(),
                        integer_arrays, boolean_arrays)).filter(_doesnt_raise)
 
 ndindices = one_of(

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -119,21 +119,19 @@ def check_same(a, idx, raw_func=lambda a, idx: a[idx],
         # Handle list indices that NumPy treats as tuple indices with a
         # deprecation warning. We want to test against the post-deprecation
         # behavior.
-        with warnings.catch_warnings(record=True) as r:
-            e_inner = None
+        e_inner = None
+        try:
             try:
                 a_raw = raw_func(a, idx)
-            except Exception:
-                _, e_inner, _ = sys.exc_info()
-        if len(r) == 1:
-            if (isinstance(r[0].message, FutureWarning) and "Using a non-tuple "
-                "sequence for multidimensional indexing is deprecated" in
-                r[0].message.args[0]):
-                idx = array(idx)
-                a_raw = raw_func(a, idx)
-            else:
-                raise AssertionError(f"Unexpected warnings raised: {[i.message for i in r]}") # pragma: no cover
-        elif e_inner:
+            except FutureWarning as w:
+                if ("Using a non-tuple sequence for multidimensional indexing is deprecated" in w.args[0]):
+                    idx = array(idx)
+                    a_raw = raw_func(a, idx)
+                else:
+                    fail(f"Unexpected warning raised: {w}")
+        except Exception:
+            _, e_inner, _ = sys.exc_info()
+        if e_inner:
             if (isinstance(e_inner, ValueError)
                 and (e_inner.args[0].startswith('operands could not be broadcast together with shapes')
                      or e_inner.args[0].startswith('non-broadcastable operand with shape'))):

--- a/ndindex/tests/test_array.py
+++ b/ndindex/tests/test_array.py
@@ -1,4 +1,4 @@
-from numpy import intp, array
+from numpy import intp, array, int16
 
 from pytest import raises
 
@@ -21,3 +21,12 @@ def test_attributes():
     assert idx.ndim == a.ndim == 2
     assert idx.shape == a.shape == (2, 2)
     assert idx.size == a.size == 4
+
+def test_copy():
+    idx = IntegerArray([1, 2])
+    idx2 = IntegerArray(idx.raw)
+    assert idx.raw is not idx2.raw
+    idx3 = IntegerArray(idx.raw, _copy=False)
+    assert idx.raw is idx3.raw
+    raises(ValueError, lambda: IntegerArray([], _copy=False))
+    raises(ValueError, lambda: IntegerArray(array([1], dtype=int16), _copy=False))

--- a/ndindex/tests/test_array.py
+++ b/ndindex/tests/test_array.py
@@ -1,8 +1,23 @@
+from numpy import intp, array
+
 from pytest import raises
 
 from ..array import ArrayIndex
+from ..integerarray import IntegerArray
 
-# Everything else is testsed in the subclasses
+from .helpers import assert_equal
+
+# Everything else is tested in the subclasses
 
 def test_ArrayIndex():
     raises(TypeError, lambda: ArrayIndex([]))
+
+def test_attributes():
+    a = array([[0, 1], [1, 0]])
+
+    idx = IntegerArray(a)
+    assert_equal(idx.array, array(a, dtype=intp))
+    assert idx.dtype == intp
+    assert idx.ndim == a.ndim == 2
+    assert idx.shape == a.shape == (2, 2)
+    assert idx.size == a.size == 4

--- a/ndindex/tests/test_assubindex.py
+++ b/ndindex/tests/test_assubindex.py
@@ -6,7 +6,7 @@ from hypothesis import given, assume, example
 from hypothesis.strategies import integers, one_of
 
 from ..ndindex import ndindex
-from .helpers import ndindices, shapes, assert_equal
+from .helpers import ndindices, common_shapes, assert_equal
 
 @example(slice(0, 0), 9007199254741193, 1)
 @example((0,), (slice(1, 2),), 3)
@@ -21,7 +21,7 @@ from .helpers import ndindices, shapes, assert_equal
 @example(slice(0, 5), 2, 10)
 @example(0, (slice(None, 0, None), Ellipsis), 1)
 @example(0, (slice(1, 2),), 1)
-@given(ndindices, ndindices, one_of(integers(0, 100), shapes))
+@given(ndindices, ndindices, one_of(integers(0, 100), common_shapes))
 def test_as_subindex_hypothesis(idx1, idx2, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_booleanarray.py
+++ b/ndindex/tests/test_booleanarray.py
@@ -60,23 +60,6 @@ def test_booleanarray_reduce_hypothesis(idx, shape):
 
     index = BooleanArray(idx)
 
-    if (index.count_nonzero == 0
-        and a.shape != index.shape
-        and prod(a.shape) == prod(index.shape)
-        and any(i != 0 and i != j for i, j in zip(index.shape, a.shape))
-        and len(a.shape) == len(index.shape)):
-        # NumPy currently allows this case, due to a bug: (see
-        # https://github.com/numpy/numpy/issues/16997 and
-        # https://github.com/numpy/numpy/pull/17010), but we disallow it.
-        with raises(IndexError, match=r"boolean index did not match indexed "
-                    r"array along dimension \d+; dimension is \d+ but "
-                    r"corresponding boolean dimension is \d+"):
-            index.reduce(shape)
-        # Make sure this really is one of the cases NumPy lets through. Remove
-        # this once a version of NumPy is released with the above fix.
-        a[index.raw]
-        return
-
     check_same(a, index.raw, ndindex_func=lambda a, x: a[x.reduce(shape).raw])
 
     try:

--- a/ndindex/tests/test_booleanarray.py
+++ b/ndindex/tests/test_booleanarray.py
@@ -62,7 +62,8 @@ def test_booleanarray_reduce_hypothesis(idx, shape):
 
     if (index.count_nonzero == 0
         and a.shape != index.shape
-        and prod(a.shape) == prod(index.shape) not in [0, 1]
+        and prod(a.shape) == prod(index.shape)
+        and any(i != 0 and i != j for i, j in zip(index.shape, a.shape))
         and len(a.shape) == len(index.shape)):
         # NumPy currently allows this case, due to a bug: (see
         # https://github.com/numpy/numpy/issues/16997 and
@@ -71,6 +72,9 @@ def test_booleanarray_reduce_hypothesis(idx, shape):
                     r"array along dimension \d+; dimension is \d+ but "
                     r"corresponding boolean dimension is \d+"):
             index.reduce(shape)
+        # Make sure this really is one of the cases NumPy lets through. Remove
+        # this once a version of NumPy is released with the above fix.
+        a[index.raw]
         return
 
     check_same(a, index.raw, func=lambda x: x.reduce(shape))
@@ -105,7 +109,8 @@ def test_booleanarray_newshape_hypothesis(idx, shape):
     index = BooleanArray(idx)
     if (index.count_nonzero == 0
         and a.shape != index.shape
-        and prod(a.shape) == prod(index.shape) not in [0, 1]
+        and prod(a.shape) == prod(index.shape)
+        and any(i != 0 and i != j for i, j in zip(index.shape, a.shape))
         and len(a.shape) == len(index.shape)):
         # NumPy currently allows this case, due to a bug: (see
         # https://github.com/numpy/numpy/issues/16997 and
@@ -113,7 +118,10 @@ def test_booleanarray_newshape_hypothesis(idx, shape):
         with raises(IndexError, match=r"boolean index did not match indexed "
                     r"array along dimension \d+; dimension is \d+ but "
                     r"corresponding boolean dimension is \d+"):
-            index.reduce(shape)
+            index.newshape(shape)
+        # Make sure this really is one of the cases NumPy lets through. Remove
+        # this once a version of NumPy is released with the above fix.
+        a[index.raw]
         return
 
     check_same(a, idx, func=func, assert_equal=assert_equal)

--- a/ndindex/tests/test_booleanarray.py
+++ b/ndindex/tests/test_booleanarray.py
@@ -88,46 +88,6 @@ def test_booleanarray_reduce_hypothesis(idx, shape):
         # give an IndexError
         assert reduced == index
 
-@example(array([[[True], [False]]]), (1, 1, 2))
-@example(full((1, 9), False), (3, 3))
-@given(boolean_arrays, one_of(shapes, integers(0, 10)))
-def test_booleanarray_newshape_hypothesis(idx, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    def raw_func(a, idx):
-        return a[idx].shape
-
-    def ndindex_func(a, index):
-        return index.newshape(shape)
-
-    def assert_equal(raw_shape, newshape):
-        assert raw_shape == newshape
-
-    index = BooleanArray(idx)
-    if (index.count_nonzero == 0
-        and a.shape != index.shape
-        and prod(a.shape) == prod(index.shape)
-        and any(i != 0 and i != j for i, j in zip(index.shape, a.shape))
-        and len(a.shape) == len(index.shape)):
-        # NumPy currently allows this case, due to a bug: (see
-        # https://github.com/numpy/numpy/issues/16997 and
-        # https://github.com/numpy/numpy/pull/17010), but we disallow it.
-        with raises(IndexError, match=r"boolean index did not match indexed "
-                    r"array along dimension \d+; dimension is \d+ but "
-                    r"corresponding boolean dimension is \d+"):
-            index.newshape(shape)
-        # Make sure this really is one of the cases NumPy lets through. Remove
-        # this once a version of NumPy is released with the above fix.
-        a[index.raw]
-        return
-
-    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
-               assert_equal=assert_equal, same_exception=False)
-
-
 @given(boolean_arrays, one_of(shapes, integers(0, 10)))
 def test_booleanarray_isempty_hypothesis(idx, shape):
     if isinstance(shape, int):

--- a/ndindex/tests/test_booleanarray.py
+++ b/ndindex/tests/test_booleanarray.py
@@ -5,7 +5,7 @@ from hypothesis.strategies import one_of, integers
 
 from pytest import raises
 
-from .helpers import boolean_arrays, shapes, check_same, assert_equal
+from .helpers import boolean_arrays, common_shapes, check_same, assert_equal
 
 from ..booleanarray import BooleanArray
 
@@ -33,12 +33,12 @@ def test_booleanarray_constructor():
     a[0] = False
     assert idx == BooleanArray([True, False])
 
-@given(boolean_arrays, shapes)
+@given(boolean_arrays, common_shapes)
 def test_booleanarray_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
     check_same(a, idx)
 
-@given(boolean_arrays, one_of(shapes, integers(0, 10)))
+@given(boolean_arrays, one_of(common_shapes, integers(0, 10)))
 def test_booleanarray_reduce_no_shape_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -51,7 +51,7 @@ def test_booleanarray_reduce_no_shape_hypothesis(idx, shape):
 
 @example(full((1, 9), True), (3, 3))
 @example(full((1, 9), False), (3, 3))
-@given(boolean_arrays, one_of(shapes, integers(0, 10)))
+@given(boolean_arrays, one_of(common_shapes, integers(0, 10)))
 def test_booleanarray_reduce_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -71,7 +71,7 @@ def test_booleanarray_reduce_hypothesis(idx, shape):
         # give an IndexError
         assert reduced == index
 
-@given(boolean_arrays, one_of(shapes, integers(0, 10)))
+@given(boolean_arrays, one_of(common_shapes, integers(0, 10)))
 def test_booleanarray_isempty_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -24,22 +24,22 @@ def test_ellipsis_hypothesis(idx, shape):
 def test_ellipsis_reduce_exhaustive():
     for n in range(10):
         a = arange(n)
-        check_same(a, ..., func=lambda x: x.reduce((n,)))
+        check_same(a, ..., ndindex_func=lambda a, x: a[x.reduce((n,)).raw])
 
 @given(ellipses(), shapes)
 def test_ellipsis_reduce_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
-    check_same(a, idx, func=lambda x: x.reduce(shape))
+    check_same(a, idx, ndindex_func=lambda a, x: a[x.reduce(shape).raw])
 
 def test_ellipsis_reduce_no_shape_exhaustive():
     for n in range(10):
         a = arange(n)
-        check_same(a, ..., func=lambda x: x.reduce())
+        check_same(a, ..., ndindex_func=lambda a, x: a[x.reduce().raw])
 
 @given(ellipses(), shapes)
 def test_ellipsis_reduce_no_shape_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
-    check_same(a, idx, func=lambda x: x.reduce())
+    check_same(a, idx, ndindex_func=lambda a, x: a[x.reduce().raw])
 
 @given(ellipses(), one_of(shapes, integers(0, 10)))
 def test_ellipsis_newshape_hypothesis(idx, shape):
@@ -48,18 +48,17 @@ def test_ellipsis_newshape_hypothesis(idx, shape):
     else:
         a = arange(prod(shape)).reshape(shape)
 
-    index = ndindex(idx)
+    def raw_func(a, idx):
+        return a[idx].shape
 
-    # Call newshape so we can see if any exceptions match
-    def func(t):
-        t.newshape(shape)
-        return t
+    def ndindex_func(a, index):
+        return index.newshape(shape)
 
-    def assert_equal(x, y):
-        newshape = index.newshape(shape)
-        assert x.shape == y.shape == newshape
+    def assert_equal(raw_shape, newshape):
+        assert raw_shape == newshape
 
-    check_same(a, idx, func=func, assert_equal=assert_equal)
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)
 
 def test_ellipsis_newshape_ndindex_input():
     raises(TypeError, lambda: ellipsis().newshape(Tuple(2, 1)))
@@ -72,24 +71,26 @@ def test_ellipsis_isempty_hypothesis(idx, shape):
     else:
         a = arange(prod(shape)).reshape(shape)
 
-    E = ndindex(idx)
+    index = ndindex(idx)
 
-    # Call isempty to see if the exceptions are the same
-    def func(E):
-        E.isempty(shape)
-        return E
+    def raw_func(a, idx):
+        return a[idx].size == 0
 
-    def assert_equal(a_raw, a_idx):
-        isempty = E.isempty()
+    def ndindex_func(a, index):
+        return index.isempty(), index.isempty(shape)
 
-        aempty = (a_raw.size == 0)
-        assert aempty == (a_idx.size == 0)
+    def assert_equal(raw_empty, ndindex_empty):
+        isempty, isempty_shape = ndindex_empty
 
         # Since idx is an ellipsis, it should never be unconditionally empty
         assert not isempty
+        # We cannot test the converse with hypothesis. isempty may be False
+        # but a[idx] could still be empty for this specific a (e.g., if a is
+        # already itself empty).
 
         # isempty() should always give the correct result for a specific
         # array after reduction
-        assert E.isempty(shape) == aempty, (E, shape)
+        assert isempty_shape == raw_empty, (index, shape)
 
-    check_same(a, idx, func=func, assert_equal=assert_equal)
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)

--- a/ndindex/tests/test_ellipsis.py
+++ b/ndindex/tests/test_ellipsis.py
@@ -3,12 +3,7 @@ from numpy import arange
 from hypothesis import given
 from hypothesis.strategies import one_of, integers
 
-from pytest import raises
-
 from ..ndindex import ndindex
-from ..tuple import Tuple
-from ..integer import Integer
-from ..ellipsis import ellipsis
 from .helpers import check_same, prod, shapes, ellipses
 
 def test_ellipsis_exhaustive():
@@ -40,29 +35,6 @@ def test_ellipsis_reduce_no_shape_exhaustive():
 def test_ellipsis_reduce_no_shape_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
     check_same(a, idx, ndindex_func=lambda a, x: a[x.reduce().raw])
-
-@given(ellipses(), one_of(shapes, integers(0, 10)))
-def test_ellipsis_newshape_hypothesis(idx, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    def raw_func(a, idx):
-        return a[idx].shape
-
-    def ndindex_func(a, index):
-        return index.newshape(shape)
-
-    def assert_equal(raw_shape, newshape):
-        assert raw_shape == newshape
-
-    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
-               assert_equal=assert_equal, same_exception=False)
-
-def test_ellipsis_newshape_ndindex_input():
-    raises(TypeError, lambda: ellipsis().newshape(Tuple(2, 1)))
-    raises(TypeError, lambda: ellipsis().newshape(Integer(2)))
 
 @given(ellipses(), one_of(shapes, integers(0, 10)))
 def test_ellipsis_isempty_hypothesis(idx, shape):

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -1,0 +1,46 @@
+from numpy import arange, prod
+
+from hypothesis import given, example
+from hypothesis.strategies import integers, one_of
+
+from ..ndindex import ndindex
+from ..tuple import Tuple
+from .helpers import ndindices, shapes, check_same
+
+
+@example(([0, 1], 0), (2, 2))
+@example((..., [0, 1], 0), (2, 2))
+@example((..., None, 0), 1)
+@example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
+@example(None, 2)
+@given(ndindices, one_of(shapes, integers(0, 10)))
+def test_expand_hypothesis(idx, shape):
+    if isinstance(shape, int):
+        a = arange(shape)
+    else:
+        a = arange(prod(shape)).reshape(shape)
+
+    index = ndindex(idx)
+
+    try:
+        expanded = index.expand(shape)
+    except IndexError:
+        pass
+    except NotImplementedError:
+        return
+    else:
+        assert isinstance(expanded, Tuple)
+        assert ... not in expanded.args
+        if isinstance(idx, tuple):
+            n_newaxis = index.args.count(None)
+        elif index == None:
+            n_newaxis = 1
+        else:
+            n_newaxis = 0
+        if isinstance(shape, int):
+            assert len(expanded.args) == 1 + n_newaxis
+        else:
+            assert len(expanded.args) == len(shape) + n_newaxis
+
+    check_same(a, index.raw, ndindex_func=lambda a, x: a[x.expand(shape).raw],
+               same_exception=False)

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -12,6 +12,7 @@ from ..tuple import Tuple
 from .helpers import ndindices, shapes, check_same
 
 
+@example((False, False), ())
 @example((-1, False), 1)
 @example((..., False), ())
 @example((arange(0),), ())

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -12,6 +12,8 @@ from ..tuple import Tuple
 from .helpers import ndindices, shapes, check_same
 
 
+@example((array([], dtype=intp), 0), (0, 0))
+@example((array([], dtype=intp), [0]), (0, 0))
 @example((..., 0, array([], dtype=intp)), (0, 0))
 @example((..., array(0), array([], dtype=intp)), (0, 0))
 @example((False, False), ())

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -12,6 +12,9 @@ from ..tuple import Tuple
 from .helpers import ndindices, shapes, check_same
 
 
+@example((-1, False), 1)
+@example((..., False), ())
+@example((arange(0),), ())
 @example(([0, 1], 0), (2, 2))
 @example((..., [0, 1], 0), (2, 2))
 @example((..., None, 0), 1)

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -48,7 +48,7 @@ def test_expand_hypothesis(idx, shape):
                 assert len(expanded.args) == len(shape) + n_newaxis
 
         # Make sure arrays are broadcasted
-        if any(isinstance(i, ArrayIndex) for i in expanded.args):
+        if any(isinstance(i, ArrayIndex) and i not in [True, False] for i in expanded.args):
             assert not any(isinstance(i, Integer) for i in expanded.args)
             assert len({i.shape for i in expanded.args if isinstance(i,
                                                                      IntegerArray)}) in [0, 1]

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -9,8 +9,7 @@ from ..booleanarray import BooleanArray
 from ..integerarray import IntegerArray
 from ..integer import Integer
 from ..tuple import Tuple
-from .helpers import ndindices, shapes, check_same
-
+from .helpers import ndindices, check_same, common_shapes
 
 @example((array([], dtype=intp), 0), (0, 0))
 @example((array([], dtype=intp), [0]), (0, 0))
@@ -25,7 +24,7 @@ from .helpers import ndindices, shapes, check_same
 @example((..., None, 0), 1)
 @example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
 @example(None, 2)
-@given(ndindices, one_of(shapes, integers(0, 10)))
+@given(ndindices, one_of(common_shapes, integers(0, 10)))
 def test_expand_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -4,7 +4,10 @@ from hypothesis import given, example
 from hypothesis.strategies import integers, one_of
 
 from ..ndindex import ndindex
+from ..array import ArrayIndex
 from ..booleanarray import BooleanArray
+from ..integerarray import IntegerArray
+from ..integer import Integer
 from ..tuple import Tuple
 from .helpers import ndindices, shapes, check_same
 
@@ -43,6 +46,16 @@ def test_expand_hypothesis(idx, shape):
                 assert len(expanded.args) == 1 + n_newaxis
             else:
                 assert len(expanded.args) == len(shape) + n_newaxis
+
+        # Make sure arrays are broadcasted
+        if any(isinstance(i, ArrayIndex) for i in expanded.args):
+            assert not any(isinstance(i, Integer) for i in expanded.args)
+            assert len({i.shape for i in expanded.args if isinstance(i,
+                                                                     IntegerArray)}) in [0, 1]
+
+        assert expanded.args.count(True) <= 1
+        assert expanded.args.count(False) <= 1
+        assert not (True in expanded.args and False in expanded.args)
 
     check_same(a, index.raw, ndindex_func=lambda a, x: a[x.expand(shape).raw],
                same_exception=False)

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -4,6 +4,7 @@ from hypothesis import given, example
 from hypothesis.strategies import integers, one_of
 
 from ..ndindex import ndindex
+from ..booleanarray import BooleanArray
 from ..tuple import Tuple
 from .helpers import ndindices, shapes, check_same
 
@@ -37,10 +38,11 @@ def test_expand_hypothesis(idx, shape):
             n_newaxis = 1
         else:
             n_newaxis = 0
-        if isinstance(shape, int):
-            assert len(expanded.args) == 1 + n_newaxis
-        else:
-            assert len(expanded.args) == len(shape) + n_newaxis
+        if not any(isinstance(i, BooleanArray) for i in expanded.args):
+            if isinstance(shape, int):
+                assert len(expanded.args) == 1 + n_newaxis
+            else:
+                assert len(expanded.args) == len(shape) + n_newaxis
 
     check_same(a, index.raw, ndindex_func=lambda a, x: a[x.expand(shape).raw],
                same_exception=False)

--- a/ndindex/tests/test_expand.py
+++ b/ndindex/tests/test_expand.py
@@ -1,4 +1,4 @@
-from numpy import arange, prod
+from numpy import arange, prod, array, intp
 
 from hypothesis import given, example
 from hypothesis.strategies import integers, one_of
@@ -12,10 +12,12 @@ from ..tuple import Tuple
 from .helpers import ndindices, shapes, check_same
 
 
+@example((..., 0, array([], dtype=intp)), (0, 0))
+@example((..., array(0), array([], dtype=intp)), (0, 0))
 @example((False, False), ())
 @example((-1, False), 1)
 @example((..., False), ())
-@example((arange(0),), ())
+@example((array([0]),), ())
 @example(([0, 1], 0), (2, 2))
 @example((..., [0, 1], 0), (2, 2))
 @example((..., None, 0), 1)

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -1,4 +1,4 @@
-from numpy import arange, int64, isin
+from numpy import arange, int64, isin, bool_
 
 from pytest import raises
 
@@ -21,7 +21,9 @@ def test_integer_args():
     assert Integer(zero) == zero
 
     raises(TypeError, lambda: Integer(1.0))
-    raises(TypeError, lambda: Integer(True))  # See the docstring of operator_index()
+    # See the docstring of operator_index()
+    raises(TypeError, lambda: Integer(True))
+    raises(TypeError, lambda: Integer(bool_(True)))
 
 def test_integer_exhaustive():
     a = arange(10)

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -20,6 +20,8 @@ def test_integer_args():
     assert isinstance(idx.raw, int)
     assert Integer(zero) == zero
 
+    raises(TypeError, lambda: Integer(1.0))
+    raises(TypeError, lambda: Integer(True))  # See the docstring of operator_index()
 
 def test_integer_exhaustive():
     a = arange(10)

--- a/ndindex/tests/test_integer.py
+++ b/ndindex/tests/test_integer.py
@@ -6,7 +6,6 @@ from hypothesis import given, example
 from hypothesis.strategies import integers, one_of
 
 from ..integer import Integer
-from ..tuple import Tuple
 from ..slice import Slice
 from .helpers import check_same, ints, prod, shapes, iterslice, assert_equal
 
@@ -102,33 +101,6 @@ def test_integer_newshape_exhaustive():
     for i in range(-10, 10):
         check_same(a, i, raw_func=raw_func, ndindex_func=ndindex_func,
                    assert_equal=assert_equal)
-
-@given(ints(), one_of(shapes, integers(0, 10)))
-def test_integer_newshape_hypothesis(i, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    def raw_func(a, idx):
-        return a[idx].shape
-
-    def ndindex_func(a, index):
-        return index.newshape(shape)
-
-    def assert_equal(raw_shape, newshape):
-        assert raw_shape == newshape
-
-    check_same(a, i, raw_func=raw_func, ndindex_func=ndindex_func,
-                assert_equal=assert_equal)
-
-def test_integer_newshape_ndindex_input():
-    raises(TypeError, lambda: Integer(1).newshape(Tuple(2, 1)))
-    raises(TypeError, lambda: Integer(1).newshape(Integer(2)))
-
-def test_integer_newshape_small_shape():
-    raises(IndexError, lambda: Integer(6).newshape(2))
-    raises(IndexError, lambda: Integer(6).newshape((4, 4)))
 
 def test_integer_as_subindex_slice_exhaustive():
     for n in range(10):

--- a/ndindex/tests/test_integerarray.py
+++ b/ndindex/tests/test_integerarray.py
@@ -52,6 +52,7 @@ def test_integerarray_reduce_no_shape_hypothesis(idx, shape):
 
 @example(array([2, 0]), (1, 0))
 @example(array(0), 1)
+@example(array([]), 0)
 @given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_reduce_hypothesis(idx, shape):
     if isinstance(shape, int):

--- a/ndindex/tests/test_integerarray.py
+++ b/ndindex/tests/test_integerarray.py
@@ -52,7 +52,7 @@ def test_integerarray_reduce_no_shape_hypothesis(idx, shape):
 
 @example(array([2, 0]), (1, 0))
 @example(array(0), 1)
-@example(array([]), 0)
+@example(array([], dtype=intp), 0)
 @given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_reduce_hypothesis(idx, shape):
     if isinstance(shape, int):

--- a/ndindex/tests/test_integerarray.py
+++ b/ndindex/tests/test_integerarray.py
@@ -5,7 +5,7 @@ from hypothesis.strategies import one_of, integers
 
 from pytest import raises
 
-from .helpers import integer_arrays, shapes, check_same, assert_equal
+from .helpers import integer_arrays, short_shapes, check_same, assert_equal
 
 from ..integer import Integer
 from ..integerarray import IntegerArray
@@ -34,12 +34,12 @@ def test_integerarray_constructor():
     a[0] = 0
     assert idx == IntegerArray([1, 2])
 
-@given(integer_arrays, shapes)
+@given(integer_arrays, short_shapes)
 def test_integerarray_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
     check_same(a, idx)
 
-@given(integer_arrays, one_of(shapes, integers(0, 10)))
+@given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_reduce_no_shape_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -51,7 +51,7 @@ def test_integerarray_reduce_no_shape_hypothesis(idx, shape):
     check_same(a, index.raw, func=lambda x: x.reduce())
 
 @example(array(0), 1)
-@given(integer_arrays, one_of(shapes, integers(0, 10)))
+@given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_reduce_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -73,7 +73,7 @@ def test_integerarray_reduce_hypothesis(idx, shape):
             assert isinstance(reduced, IntegerArray)
             assert (reduced.raw >= 0).all()
 
-@given(integer_arrays, one_of(shapes, integers(0, 10)))
+@given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_newshape_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -93,7 +93,7 @@ def test_integerarray_newshape_hypothesis(idx, shape):
 
 @example([], (1,))
 @example([0], (1, 0))
-@given(integer_arrays, one_of(shapes, integers(0, 10)))
+@given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_isempty_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_integerarray.py
+++ b/ndindex/tests/test_integerarray.py
@@ -73,25 +73,6 @@ def test_integerarray_reduce_hypothesis(idx, shape):
             assert isinstance(reduced, IntegerArray)
             assert (reduced.raw >= 0).all()
 
-@given(integer_arrays, one_of(short_shapes, integers(0, 10)))
-def test_integerarray_newshape_hypothesis(idx, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    def raw_func(a, idx):
-        return a[idx].shape
-
-    def ndindex_func(a, index):
-        return index.newshape(shape)
-
-    def assert_equal(raw_shape, newshape):
-        assert raw_shape == newshape
-
-    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
-               assert_equal=assert_equal, same_exception=False)
-
 @example([], (1,))
 @example([0], (1, 0))
 @given(integer_arrays, one_of(short_shapes, integers(0, 10)))

--- a/ndindex/tests/test_integerarray.py
+++ b/ndindex/tests/test_integerarray.py
@@ -50,6 +50,7 @@ def test_integerarray_reduce_no_shape_hypothesis(idx, shape):
 
     check_same(a, index.raw, ndindex_func=lambda a, x: a[x.reduce().raw])
 
+@example(array([2, 0]), (1, 0))
 @example(array(0), 1)
 @given(integer_arrays, one_of(short_shapes, integers(0, 10)))
 def test_integerarray_reduce_hypothesis(idx, shape):

--- a/ndindex/tests/test_integerarray.py
+++ b/ndindex/tests/test_integerarray.py
@@ -48,7 +48,7 @@ def test_integerarray_reduce_no_shape_hypothesis(idx, shape):
 
     index = IntegerArray(idx)
 
-    check_same(a, index.raw, func=lambda x: x.reduce())
+    check_same(a, index.raw, ndindex_func=lambda a, x: a[x.reduce().raw])
 
 @example(array(0), 1)
 @given(integer_arrays, one_of(short_shapes, integers(0, 10)))
@@ -60,7 +60,7 @@ def test_integerarray_reduce_hypothesis(idx, shape):
 
     index = IntegerArray(idx)
 
-    check_same(a, index.raw, func=lambda x: x.reduce(shape))
+    check_same(a, index.raw, ndindex_func=lambda a, x: a[x.reduce(shape).raw])
 
     try:
         reduced = index.reduce(shape)
@@ -80,16 +80,17 @@ def test_integerarray_newshape_hypothesis(idx, shape):
     else:
         a = arange(prod(shape)).reshape(shape)
 
-    def assert_equal(x, y):
-        newshape = IntegerArray(idx).newshape(shape)
-        assert x.shape == y.shape == newshape
+    def raw_func(a, idx):
+        return a[idx].shape
 
-    # Call newshape so we can see if any exceptions match
-    def func(idx):
-        idx.newshape(shape)
-        return idx
+    def ndindex_func(a, index):
+        return index.newshape(shape)
 
-    check_same(a, idx, func=func, assert_equal=assert_equal)
+    def assert_equal(raw_shape, newshape):
+        assert raw_shape == newshape
+
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)
 
 @example([], (1,))
 @example([0], (1, 0))
@@ -102,26 +103,32 @@ def test_integerarray_isempty_hypothesis(idx, shape):
 
     index = IntegerArray(idx)
 
-    # Call isempty to see if the exceptions are the same
-    def func(index):
-        index.isempty(shape)
-        return index
 
-    def assert_equal(a_raw, a_idx):
-        isempty = index.isempty()
-        isempty_shape = index.isempty(shape)
+    def raw_func(a, idx):
+        return a[idx].size == 0
 
-        aempty = (a_raw.size == 0)
-        assert aempty == (a_idx.size == 0)
+    def ndindex_func(a, index):
+        return index.isempty(), index.isempty(shape)
+
+    def assert_equal(raw_empty, ndindex_empty):
+        isempty, isempty_shape = ndindex_empty
+
+        # If isempty is True then a[t] should be empty
+        if isempty:
+            assert raw_empty, (index, shape)
+        # We cannot test the converse with hypothesis. isempty may be False
+        # but a[idx] could still be empty for this specific a (e.g., if a is
+        # already itself empty).
 
         # If isempty is true with no shape it should be true for a specific
         # shape. The converse is not true because the indexed array could be
         # empty.
         if isempty:
-            assert isempty_shape
+            assert isempty_shape, (index, shape)
 
         # isempty() should always give the correct result for a specific
         # array after reduction
-        assert isempty_shape == aempty, (index, shape)
+        assert isempty_shape == raw_empty, (index, shape)
 
-    check_same(a, idx, func=func, assert_equal=assert_equal)
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -48,10 +48,12 @@ def test_ndindex(idx):
         elif isinstance(idx, tuple):
             assert type(index.raw) == type(idx)
             assert len(index.raw) == len(idx)
-            for i, j in zip(index.raw, idx):
+            assert index.args == index.raw
+            for i, j in zip(idx, index.args):
                 test_raw_eq(i, j)
         else:
             assert index.raw == idx
+    test_raw_eq(idx, index)
     assert ndindex(index.raw) == index
 
 def test_ndindex_invalid():

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -39,13 +39,19 @@ def test_eq(idx):
 def test_ndindex(idx):
     index = ndindex(idx)
     assert index == idx
-    if isinstance(idx, np.ndarray):
-        assert_equal(index.raw, idx)
-    elif isinstance(idx, list):
-        assert index.dtype in [np.intp, np.bool_]
-        assert_equal(index.raw, np.asarray(idx, dtype=index.dtype))
-    else:
-        assert index.raw == idx
+    def test_raw_eq(idx, index):
+        if isinstance(idx, np.ndarray):
+            assert_equal(index.raw, idx)
+        elif isinstance(idx, list):
+            assert index.dtype in [np.intp, np.bool_]
+            assert_equal(index.raw, np.asarray(idx, dtype=index.dtype))
+        elif isinstance(idx, tuple):
+            assert type(index.raw) == type(idx)
+            assert len(index.raw) == len(idx)
+            for i, j in zip(index.raw, idx):
+                test_raw_eq(i, j)
+        else:
+            assert index.raw == idx
     assert ndindex(index.raw) == index
 
 def test_ndindex_invalid():

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -110,3 +110,4 @@ def test_asshape():
     raises(TypeError, lambda: asshape(...))
     raises(TypeError, lambda: asshape(Integer(1)))
     raises(TypeError, lambda: asshape(Tuple(1, 2)))
+    raises(TypeError, lambda: asshape((True,)))

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -75,6 +75,9 @@ def test_signature():
     sig = inspect.signature(Integer)
     assert sig.parameters.keys() == {'idx'}
 
+
+@example(([0, 1],))
+@example((IntegerArray([], (0, 1)),))
 @example(IntegerArray([], (0, 1)))
 @example((1, ..., slice(1, 2)))
 # eval can sometimes be slower than the default deadline of 200ms for large

--- a/ndindex/tests/test_ndindex.py
+++ b/ndindex/tests/test_ndindex.py
@@ -84,17 +84,14 @@ def test_signature():
 # array indices
 @settings(deadline=None)
 @given(ndindices)
-def test_repr(idx):
+def test_repr_str(idx):
     # The repr form should be re-creatable
     index = ndindex(idx)
     d = {}
     exec("from ndindex import *", d)
     assert eval(repr(index), d) == idx
 
-@given(ndindices)
-def test_str(idx):
     # Str may not be re-creatable. Just test that it doesn't give an exception.
-    index = ndindex(idx)
     str(index)
 
 def test_asshape():

--- a/ndindex/tests/test_newaxis.py
+++ b/ndindex/tests/test_newaxis.py
@@ -26,24 +26,24 @@ def test_newaxis_hypothesis(idx, shape):
 def test_newaxis_reduce_exhaustive():
     for n in range(10):
         a = arange(n)
-        check_same(a, newaxis, func=lambda x: x.reduce((n,)))
+        check_same(a, newaxis, ndindex_func=lambda a, x: a[x.reduce((n,)).raw])
 
 
 @given(newaxes(), shapes)
 def test_newaxis_reduce_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
-    check_same(a, idx, func=lambda x: x.reduce(shape))
+    check_same(a, idx, ndindex_func=lambda a, x: a[x.reduce(shape).raw])
 
 
 def test_newaxis_reduce_no_shape_exhaustive():
     for n in range(10):
         a = arange(n)
-        check_same(a, newaxis, func=lambda x: x.reduce())
+        check_same(a, newaxis, ndindex_func=lambda a, x: a[x.reduce().raw])
 
 @given(newaxes(), shapes)
 def test_newaxis_reduce_no_shape_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
-    check_same(a, idx, func=lambda x: x.reduce())
+    check_same(a, idx, ndindex_func=lambda a, x: a[x.reduce().raw])
 
 @given(newaxes(), one_of(shapes, integers(0, 10)))
 def test_newaxis_newshape_hypothesis(idx, shape):
@@ -52,18 +52,17 @@ def test_newaxis_newshape_hypothesis(idx, shape):
     else:
         a = arange(prod(shape)).reshape(shape)
 
-    index = ndindex(idx)
+    def raw_func(a, idx):
+        return a[idx].shape
 
-    # Call newshape so we can see if any exceptions match
-    def func(t):
-        t.newshape(shape)
-        return t
+    def ndindex_func(a, index):
+        return index.newshape(shape)
 
-    def assert_equal(x, y):
-        newshape = index.newshape(shape)
-        assert x.shape == y.shape == newshape
+    def assert_equal(raw_shape, newshape):
+        assert raw_shape == newshape
 
-    check_same(a, idx, func=func, assert_equal=assert_equal)
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)
 
 def test_newaxis_newshape_ndindex_input():
     raises(TypeError, lambda: Newaxis().newshape(Tuple(2, 1)))
@@ -76,24 +75,27 @@ def test_newaxis_isempty_hypothesis(idx, shape):
     else:
         a = arange(prod(shape)).reshape(shape)
 
-    E = ndindex(idx)
+    index = ndindex(idx)
 
-    # Call isempty to see if the exceptions are the same
-    def func(E):
-        E.isempty(shape)
-        return E
 
-    def assert_equal(a_raw, a_idx):
-        isempty = E.isempty()
+    def raw_func(a, idx):
+        return a[idx].size == 0
 
-        aempty = (a_raw.size == 0)
-        assert aempty == (a_idx.size == 0)
+    def ndindex_func(a, index):
+        return index.isempty(), index.isempty(shape)
+
+    def assert_equal(raw_empty, ndindex_empty):
+        isempty, isempty_shape = ndindex_empty
 
         # Since idx is a newaxis, it should never be unconditionally empty
         assert not isempty
+        # We cannot test the converse with hypothesis. isempty may be False
+        # but a[idx] could still be empty for this specific a (e.g., if a is
+        # already itself empty).
 
         # isempty() should always give the correct result for a specific
         # array after reduction
-        assert E.isempty(shape) == aempty, (E, shape)
+        assert isempty_shape == raw_empty, (index, shape)
 
-    check_same(a, idx, func=func, assert_equal=assert_equal)
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)

--- a/ndindex/tests/test_newaxis.py
+++ b/ndindex/tests/test_newaxis.py
@@ -1,14 +1,9 @@
 from numpy import arange, newaxis
 
-from pytest import raises
-
 from hypothesis import given
 from hypothesis.strategies import one_of, integers
 
 from ..ndindex import ndindex
-from ..integer import Integer
-from ..tuple import Tuple
-from ..newaxis import Newaxis
 from .helpers import check_same, prod, shapes, newaxes
 
 def test_newaxis_exhaustive():
@@ -44,29 +39,6 @@ def test_newaxis_reduce_no_shape_exhaustive():
 def test_newaxis_reduce_no_shape_hypothesis(idx, shape):
     a = arange(prod(shape)).reshape(shape)
     check_same(a, idx, ndindex_func=lambda a, x: a[x.reduce().raw])
-
-@given(newaxes(), one_of(shapes, integers(0, 10)))
-def test_newaxis_newshape_hypothesis(idx, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    def raw_func(a, idx):
-        return a[idx].shape
-
-    def ndindex_func(a, index):
-        return index.newshape(shape)
-
-    def assert_equal(raw_shape, newshape):
-        assert raw_shape == newshape
-
-    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
-               assert_equal=assert_equal, same_exception=False)
-
-def test_newaxis_newshape_ndindex_input():
-    raises(TypeError, lambda: Newaxis().newshape(Tuple(2, 1)))
-    raises(TypeError, lambda: Newaxis().newshape(Integer(2)))
 
 @given(newaxes(), one_of(shapes, integers(0, 10)))
 def test_newaxis_isempty_hypothesis(idx, shape):

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -10,6 +10,7 @@ from ..tuple import Tuple
 from ..integer import Integer
 from .helpers import ndindices, short_shapes, check_same
 
+@example(array([], dtype=bool), 0)
 @example(array([[[True], [False]]]), (1, 1, 2))
 @example(full((1, 9), False), (3, 3))
 @example(([0, 1], 0), (2, 2))

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -8,8 +8,7 @@ from hypothesis.strategies import integers, one_of
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
-from .helpers import ndindices, short_shapes, check_same
-
+from .helpers import ndindices, check_same, common_shapes
 
 @example(..., 0)
 @example((True,), ())
@@ -24,7 +23,7 @@ from .helpers import ndindices, short_shapes, check_same
 @example(([0, 0, 0], [0, 0]), (2, 2))
 @example((0, None, 0, ..., 0, None, 0), (2, 2, 2, 2, 2, 2, 2))
 @example((0, slice(None), ..., slice(None), 3), (2, 3, 4, 5, 6, 7))
-@given(ndindices, one_of(short_shapes, integers(0, 10)))
+@given(ndindices, one_of(common_shapes, integers(0, 10)))
 def test_newshape_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -8,7 +8,6 @@ from hypothesis.strategies import integers, one_of
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
-from ..booleanarray import BooleanArray
 from .helpers import ndindices, short_shapes, check_same
 
 @example(array([[[True], [False]]]), (1, 1, 2))
@@ -29,24 +28,6 @@ def test_newshape_hypothesis(idx, shape):
     except IndexError:
         pass
     else:
-        if (isinstance(index, BooleanArray)
-            and index.count_nonzero == 0
-            and a.shape != index.shape
-            and prod(a.shape) == prod(index.shape)
-            and any(i != 0 and i != j for i, j in zip(index.shape, a.shape))
-            and len(a.shape) == len(index.shape)):
-            # NumPy currently allows this case, due to a bug: (see
-            # https://github.com/numpy/numpy/issues/16997 and
-            # https://github.com/numpy/numpy/pull/17010), but we disallow it.
-            with raises(IndexError, match=r"boolean index did not match indexed "
-                        r"array along dimension \d+; dimension is \d+ but "
-                        r"corresponding boolean dimension is \d+"):
-                index.newshape(shape)
-            # Make sure this really is one of the cases NumPy lets through. Remove
-            # this once a version of NumPy is released with the above fix.
-            a[index.raw]
-            return
-
         # Make sure ndindex input gives an error
         raises(TypeError, lambda: index.newshape(Tuple(2, 1)))
         raises(TypeError, lambda: index.newshape(Integer(2)))

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -10,8 +10,12 @@ from ..tuple import Tuple
 from ..integer import Integer
 from .helpers import ndindices, short_shapes, check_same
 
+
+@example(([[True, False], [True, False]], [True, True], slice(0, 2)), ((2, 2, 2, 3, 3)))
+@example((array([], dtype=bool),), (0, 0))
 @example((False, False), ())
 @example(array([], dtype=bool), 0)
+@example((array([], dtype=bool),), 0)
 @example(array([[[True], [False]]]), (1, 1, 2))
 @example(full((1, 9), False), (3, 3))
 @example(([0, 1], 0), (2, 2))

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -11,6 +11,7 @@ from ..integer import Integer
 from .helpers import ndindices, short_shapes, check_same
 
 
+@example((True,), ())
 @example(([[True, False], [True, False]], [True, True], slice(0, 2)), ((2, 2, 2, 3, 3)))
 @example((array([], dtype=bool),), (0, 0))
 @example((False, False), ())

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -10,6 +10,7 @@ from ..tuple import Tuple
 from ..integer import Integer
 from .helpers import ndindices, short_shapes, check_same
 
+@example((False, False), ())
 @example(array([], dtype=bool), 0)
 @example(array([[[True], [False]]]), (1, 1, 2))
 @example(full((1, 9), False), (3, 3))

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -1,0 +1,65 @@
+from pytest import raises
+
+from numpy import arange, prod, array, full
+
+from hypothesis import given, example
+from hypothesis.strategies import integers, one_of
+
+from ..ndindex import ndindex
+from ..tuple import Tuple
+from ..integer import Integer
+from ..booleanarray import BooleanArray
+from .helpers import ndindices, short_shapes, check_same
+
+@example(array([[[True], [False]]]), (1, 1, 2))
+@example(full((1, 9), False), (3, 3))
+@example(([0, 1], 0), (2, 2))
+@example(([0, 0, 0], [0, 0]), (2, 2))
+@example((0, None, 0, ..., 0, None, 0), (2, 2, 2, 2, 2, 2, 2))
+@example((0, slice(None), ..., slice(None), 3), (2, 3, 4, 5, 6, 7))
+@given(ndindices, one_of(short_shapes, integers(0, 10)))
+def test_newshape_hypothesis(idx, shape):
+    if isinstance(shape, int):
+        a = arange(shape)
+    else:
+        a = arange(prod(shape)).reshape(shape)
+
+    try:
+        index = ndindex(idx)
+    except IndexError:
+        pass
+    else:
+        if (isinstance(index, BooleanArray)
+            and index.count_nonzero == 0
+            and a.shape != index.shape
+            and prod(a.shape) == prod(index.shape)
+            and any(i != 0 and i != j for i, j in zip(index.shape, a.shape))
+            and len(a.shape) == len(index.shape)):
+            # NumPy currently allows this case, due to a bug: (see
+            # https://github.com/numpy/numpy/issues/16997 and
+            # https://github.com/numpy/numpy/pull/17010), but we disallow it.
+            with raises(IndexError, match=r"boolean index did not match indexed "
+                        r"array along dimension \d+; dimension is \d+ but "
+                        r"corresponding boolean dimension is \d+"):
+                index.newshape(shape)
+            # Make sure this really is one of the cases NumPy lets through. Remove
+            # this once a version of NumPy is released with the above fix.
+            a[index.raw]
+            return
+
+        # Make sure ndindex input gives an error
+        raises(TypeError, lambda: index.newshape(Tuple(2, 1)))
+        raises(TypeError, lambda: index.newshape(Integer(2)))
+
+    def raw_func(a, idx):
+        return a[idx].shape
+
+    def ndindex_func(a, index):
+        return index.newshape(shape)
+
+    def assert_equal(raw_shape, newshape):
+        assert raw_shape == newshape
+
+
+    check_same(a, idx, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)

--- a/ndindex/tests/test_newshape.py
+++ b/ndindex/tests/test_newshape.py
@@ -11,6 +11,7 @@ from ..integer import Integer
 from .helpers import ndindices, short_shapes, check_same
 
 
+@example(..., 0)
 @example((True,), ())
 @example(([[True, False], [True, False]], [True, True], slice(0, 2)), ((2, 2, 2, 3, 3)))
 @example((array([], dtype=bool),), (0, 0))

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -6,7 +6,6 @@ from hypothesis import given, assume, example
 from hypothesis.strategies import integers, one_of
 
 from ..slice import Slice
-from ..tuple import Tuple
 from ..integer import Integer
 from ..ellipsis import ellipsis
 from .helpers import check_same, slices, prod, shapes, iterslice, assert_equal
@@ -219,35 +218,6 @@ def test_slice_newshape_exhaustive():
 
             check_same(a, S.raw, raw_func=raw_func, ndindex_func=ndindex_func,
                    assert_equal=assert_equal)
-
-@given(slices(), one_of(shapes, integers(0, 10)))
-def test_slice_newshape_hypothesis(s, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    try:
-        Slice(s)
-    except ValueError: # pragma: no cover
-        assume(False)
-
-
-    def raw_func(a, idx):
-        return a[idx].shape
-
-    def ndindex_func(a, index):
-        return index.newshape(shape)
-
-    def assert_equal(raw_shape, newshape):
-        assert raw_shape == newshape
-
-    check_same(a, s, raw_func=raw_func, ndindex_func=ndindex_func,
-               assert_equal=assert_equal)
-
-def test_slice_newshape_ndindex_input():
-    raises(TypeError, lambda: Slice(6).newshape(Tuple(2, 1)))
-    raises(TypeError, lambda: Slice(6).newshape(Integer(2)))
 
 def test_slice_as_subindex_slice_exhaustive():
     # We have to restrict the range of the exhaustive test to get something

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -16,6 +16,8 @@ def test_slice_args():
     # TODO: Incorporate this into the normal slice tests
     raises(TypeError, lambda: slice())
     raises(TypeError, lambda: Slice())
+    raises(TypeError, lambda: Slice(1.0))
+    raises(TypeError, lambda: Slice(True)) # See docstring of operator_index()
 
     S = Slice(1)
     assert S == Slice(S) == Slice(None, 1) == Slice(None, 1, None) == Slice(None, 1, None)

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from numpy import arange, isin
+from numpy import arange, isin, bool_
 
 from hypothesis import given, assume, example
 from hypothesis.strategies import integers, one_of
@@ -17,7 +17,9 @@ def test_slice_args():
     raises(TypeError, lambda: slice())
     raises(TypeError, lambda: Slice())
     raises(TypeError, lambda: Slice(1.0))
-    raises(TypeError, lambda: Slice(True)) # See docstring of operator_index()
+    # See docstring of operator_index()
+    raises(TypeError, lambda: Slice(True))
+    raises(TypeError, lambda: Slice(bool_(True)))
 
     S = Slice(1)
     assert S == Slice(S) == Slice(None, 1) == Slice(None, 1, None) == Slice(None, 1, None)

--- a/ndindex/tests/test_slice.py
+++ b/ndindex/tests/test_slice.py
@@ -118,7 +118,7 @@ def test_slice_reduce_no_shape_exhaustive():
             except ValueError:
                 continue
 
-            check_same(a, S.raw, func=lambda x: x.reduce())
+            check_same(a, S.raw, ndindex_func=lambda a, x: a[x.reduce().raw])
 
             # Check the conditions stated by the Slice.reduce() docstring
             reduced = S.reduce()
@@ -136,7 +136,7 @@ def test_slice_reduce_no_shape_hypothesis(s, shape):
     # The axis argument is tested implicitly in the Tuple.reduce test. It is
     # difficult to test here because we would have to pass in a Tuple to
     # check_same.
-    check_same(a, S.raw, func=lambda x: x.reduce())
+    check_same(a, S.raw, ndindex_func=lambda a, x: a[x.reduce().raw])
 
     # Check the conditions stated by the Slice.reduce() docstring
     reduced = S.reduce()
@@ -152,7 +152,7 @@ def test_slice_reduce_exhaustive():
             except ValueError:
                 continue
 
-            check_same(a, S.raw, func=lambda x: x.reduce((n,)))
+            check_same(a, S.raw, ndindex_func=lambda a, x: a[x.reduce((n,)).raw])
 
             # Check the conditions stated by the Slice.reduce() docstring
             # TODO: Factor this out so we can also test it in the tuple reduce
@@ -180,7 +180,7 @@ def test_slice_reduce_hypothesis(s, shape):
     # The axis argument is tested implicitly in the Tuple.reduce test. It is
     # difficult to test here because we would have to pass in a Tuple to
     # check_same.
-    check_same(a, S.raw, func=lambda x: x.reduce(shape))
+    check_same(a, S.raw, ndindex_func=lambda a, x: a[x.reduce(shape).raw])
 
     # Check the conditions stated by the Slice.reduce() docstring
     try:
@@ -198,14 +198,14 @@ def test_slice_reduce_hypothesis(s, shape):
 
 
 def test_slice_newshape_exhaustive():
-    # Call newshape so we can see if any exceptions match
-    def func(S):
-        S.newshape(shape)
-        return S
+    def raw_func(a, idx):
+        return a[idx].shape
 
-    def assert_equal(x, y):
-        newshape = S.newshape(shape)
-        assert x.shape == y.shape == newshape
+    def ndindex_func(a, index):
+        return index.newshape(shape)
+
+    def assert_equal(raw_shape, newshape):
+        assert raw_shape == newshape
 
     for n in range(10):
         shape = n
@@ -217,8 +217,8 @@ def test_slice_newshape_exhaustive():
             except ValueError:
                 continue
 
-            check_same(a, S.raw, func=func, assert_equal=assert_equal)
-
+            check_same(a, S.raw, raw_func=raw_func, ndindex_func=ndindex_func,
+                   assert_equal=assert_equal)
 
 @given(slices(), one_of(shapes, integers(0, 10)))
 def test_slice_newshape_hypothesis(s, shape):
@@ -228,20 +228,22 @@ def test_slice_newshape_hypothesis(s, shape):
         a = arange(prod(shape)).reshape(shape)
 
     try:
-        S = Slice(s)
+        Slice(s)
     except ValueError: # pragma: no cover
         assume(False)
 
-    # Call newshape so we can see if any exceptions match
-    def func(S):
-        S.newshape(shape)
-        return S
 
-    def assert_equal(x, y):
-        newshape = S.newshape(shape)
-        assert x.shape == y.shape == newshape
+    def raw_func(a, idx):
+        return a[idx].shape
 
-    check_same(a, S.raw, func=func, assert_equal=assert_equal)
+    def ndindex_func(a, index):
+        return index.newshape(shape)
+
+    def assert_equal(raw_shape, newshape):
+        assert raw_shape == newshape
+
+    check_same(a, s, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal)
 
 def test_slice_newshape_ndindex_input():
     raises(TypeError, lambda: Slice(6).newshape(Tuple(2, 1)))
@@ -390,26 +392,31 @@ def test_slice_isempty_hypothesis(s, shape):
     except (IndexError, ValueError): # pragma: no cover
         assume(False)
 
-    # Call isempty to see if the exceptions are the same
-    def func(S):
-        S.isempty(shape)
-        return S
+    def raw_func(a, s):
+        return a[s].size == 0
 
-    def assert_equal(a_raw, a_idx):
-        isempty = S.isempty()
+    def ndindex_func(a, S):
+        return S.isempty(), S.isempty(shape)
 
-        aempty = (a_raw.size == 0)
-        assert aempty == (a_idx.size == 0)
+    def assert_equal(raw_empty, ndindex_empty):
+        isempty, isempty_shape = ndindex_empty
 
-        # If isempty is True then a[s] should be empty
+        # If isempty is True then a[t] should be empty
         if isempty:
-            assert aempty, (S, shape)
-        # We cannot test the converse with hypothesis. isempty may be False but
-        # a[s] could still be empty for this specific a (e.g., if a is already
-        # itself empty).
+            assert raw_empty, (S, shape)
+        # We cannot test the converse with hypothesis. isempty may be False
+        # but a[s] could still be empty for this specific a (e.g., if a is
+        # already itself empty).
+
+        # If isempty is true with no shape it should be true for a specific
+        # shape. The converse is not true because the indexed array could be
+        # empty.
+        if isempty:
+            assert isempty_shape, (S, shape)
 
         # isempty() should always give the correct result for a specific
         # array after reduction
-        assert S.isempty(shape) == aempty, (S, shape)
+        assert isempty_shape == raw_empty, (S, shape)
 
-    check_same(a, s, func=func, assert_equal=assert_equal)
+    check_same(a, s, raw_func=raw_func, ndindex_func=ndindex_func,
+               assert_equal=assert_equal, same_exception=False)

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -81,6 +81,7 @@ def test_ellipsis_index(t, shape):
 
     check_same(a, t, ndindex_func=ndindex_func)
 
+@example((True, 0, False), 1)
 @example((..., None), ())
 @given(Tuples, one_of(shapes, integers(0, 10)))
 def test_tuple_reduce_no_shape_hypothesis(t, shape):

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -19,6 +19,22 @@ def test_tuple_constructor():
     raises(ValueError, lambda: Tuple((1, 2, 3)))
     raises(ValueError, lambda: Tuple(0, (1, 2, 3)))
 
+    # Test NotImplementedError behavior for Tuples with arrays split up by
+    # slices, ellipses, and newaxes.
+    raises(NotImplementedError, lambda: Tuple(0, slice(None), [0]))
+    raises(NotImplementedError, lambda: Tuple([0], slice(None), [0]))
+    raises(NotImplementedError, lambda: Tuple([0], slice(None), [0]))
+    raises(NotImplementedError, lambda: Tuple(0, ..., [0]))
+    raises(NotImplementedError, lambda: Tuple([0], ..., [0]))
+    raises(NotImplementedError, lambda: Tuple([0], ..., [0]))
+    raises(NotImplementedError, lambda: Tuple(0, None, [0]))
+    raises(NotImplementedError, lambda: Tuple([0], None, [0]))
+    raises(NotImplementedError, lambda: Tuple([0], None, [0]))
+    # Make sure this doesn't raise
+    Tuple(0, slice(None), 0)
+    Tuple(0, ..., 0)
+    Tuple(0, None, 0)
+
 def test_tuple_exhaustive():
     # Exhaustive tests here have to be very limited because of combinatorial
     # explosion.

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -13,6 +13,12 @@ from ..integer import Integer
 from .helpers import check_same, Tuples, prod, shapes, iterslice, ndindices
 
 
+def test_tuple_constructor():
+    # Test things in the Tuple constructor that are not tested by the other
+    # tests below.
+    raises(ValueError, lambda: Tuple((1, 2, 3)))
+    raises(ValueError, lambda: Tuple(0, (1, 2, 3)))
+
 def test_tuple_exhaustive():
     # Exhaustive tests here have to be very limited because of combinatorial
     # explosion.

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -10,7 +10,7 @@ from pytest import raises
 from ..ndindex import ndindex
 from ..tuple import Tuple
 from ..integer import Integer
-from .helpers import check_same, Tuples, prod, shapes, iterslice
+from .helpers import check_same, Tuples, prod, common_shapes, iterslice
 
 def test_tuple_constructor():
     # Test things in the Tuple constructor that are not tested by the other
@@ -66,12 +66,12 @@ def test_tuple_exhaustive():
                     else:
                         assert index.has_ellipsis == (type(...) in (t1, t2, t3))
 
-@given(Tuples, shapes)
+@given(Tuples, common_shapes)
 def test_tuples_hypothesis(t, shape):
     a = arange(prod(shape)).reshape(shape)
     check_same(a, t, same_exception=False)
 
-@given(Tuples, shapes)
+@given(Tuples, common_shapes)
 def test_ellipsis_index(t, shape):
     a = arange(prod(shape)).reshape(shape)
     # Don't know if there is a better way to test ellipsis_idx
@@ -83,7 +83,7 @@ def test_ellipsis_index(t, shape):
 
 @example((True, 0, False), 1)
 @example((..., None), ())
-@given(Tuples, one_of(shapes, integers(0, 10)))
+@given(Tuples, one_of(common_shapes, integers(0, 10)))
 def test_tuple_reduce_no_shape_hypothesis(t, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -108,7 +108,7 @@ def test_tuple_reduce_no_shape_hypothesis(t, shape):
 @example((0, ..., slice(None)), (2, 3, 4, 5, 6, 7))
 @example((slice(None, None, -1),), (2,))
 @example((..., slice(None, None, -1),), (2, 3, 4))
-@given(Tuples, one_of(shapes, integers(0, 10)))
+@given(Tuples, one_of(common_shapes, integers(0, 10)))
 def test_tuple_reduce_hypothesis(t, shape):
     if isinstance(shape, int):
         a = arange(shape)
@@ -155,7 +155,7 @@ def test_tuple_reduce_explicit():
 
 @example((slice(0, 0),), 2)
 @example((0, slice(0, 0)), (1, 2))
-@given(Tuples, one_of(shapes, integers(0, 10)))
+@given(Tuples, one_of(common_shapes, integers(0, 10)))
 def test_tuple_isempty_hypothesis(t, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -149,6 +149,8 @@ def test_tuple_reduce_explicit():
         check_same(a, before.raw, ndindex_func=lambda a, x:
                    a[x.reduce(shape).raw])
 
+@example(([0, 1], 0), (2, 2))
+@example((..., [0, 1], 0), (2, 2))
 @example((..., None, 0), 1)
 @example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
 @given(Tuples, one_of(shapes, integers(0, 10)))

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -1,6 +1,6 @@
 from itertools import product
 
-from numpy import arange
+from numpy import arange, array, intp
 
 from hypothesis import given, example
 from hypothesis.strategies import integers, one_of
@@ -100,6 +100,8 @@ def test_tuple_reduce_no_shape_hypothesis(t, shape):
         assert len(reduced.args) != 1
         assert reduced == () or reduced.args[-1] != ...
 
+@example((array([], dtype=intp), 0), (0, 0))
+@example((array([], dtype=intp), [0]), (0, 0))
 @example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
 @example((0, slice(None), ..., slice(None), 3), (2, 3, 4, 5, 6, 7))
 @example((0, ..., slice(None)), (2, 3, 4, 5, 6, 7))

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -200,7 +200,7 @@ def test_ndindex_expand_hypothesis(idx, shape):
         assert isinstance(expanded, Tuple)
         assert ... not in expanded.args
         if isinstance(idx, tuple):
-            n_newaxis = idx.count(None)
+            n_newaxis = index.args.count(None)
         elif index == None:
             n_newaxis = 1
         else:

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -214,6 +214,7 @@ def test_ndindex_expand_hypothesis(idx, shape):
                same_exception=False)
 
 
+@example(([0, 1], 0), (2, 2))
 @example(([0, 0, 0], [0, 0]), (2, 2))
 @example((0, None, 0, ..., 0, None, 0), (2, 2, 2, 2, 2, 2, 2))
 @example((0, slice(None), ..., slice(None), 3), (2, 3, 4, 5, 6, 7))

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -153,33 +153,6 @@ def test_tuple_reduce_explicit():
 @example((..., [0, 1], 0), (2, 2))
 @example((..., None, 0), 1)
 @example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
-@given(Tuples, one_of(shapes, integers(0, 10)))
-def test_tuple_expand_hypothesis(t, shape):
-    if isinstance(shape, int):
-        a = arange(shape)
-    else:
-        a = arange(prod(shape)).reshape(shape)
-
-    index = Tuple(*t)
-
-    try:
-        expanded = index.expand(shape)
-    except (IndexError, NotImplementedError):
-        pass
-    else:
-        assert isinstance(expanded, Tuple)
-        assert ... not in expanded.args
-        n_newaxis = index.args.count(None)
-        if isinstance(shape, int):
-            assert len(expanded.args) == 1 + n_newaxis
-        else:
-            assert len(expanded.args) == len(shape) + n_newaxis
-
-    check_same(a, index.raw, ndindex_func=lambda a, x: a[x.expand(shape).raw],
-               same_exception=False)
-
-# This is here because expand() always returns a Tuple, so it is very similar
-# to the test_tuple_expand_hypothesis test.
 @example(None, 2)
 @given(ndindices, one_of(shapes, integers(0, 10)))
 def test_ndindex_expand_hypothesis(idx, shape):

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -101,6 +101,7 @@ def test_tuple_reduce_no_shape_hypothesis(t, shape):
         assert reduced == () or reduced.args[-1] != ...
 
 @example((array([], dtype=intp), 0), (0, 0))
+@example((array([], dtype=intp), array(0)), (0, 0))
 @example((array([], dtype=intp), [0]), (0, 0))
 @example((0, 1, ..., 2, 3), (2, 3, 4, 5, 6, 7))
 @example((0, slice(None), ..., slice(None), 3), (2, 3, 4, 5, 6, 7))

--- a/ndindex/tests/test_tuple.py
+++ b/ndindex/tests/test_tuple.py
@@ -81,6 +81,7 @@ def test_ellipsis_index(t, shape):
 
     check_same(a, t, ndindex_func=ndindex_func)
 
+@example((..., None), ())
 @given(Tuples, one_of(shapes, integers(0, 10)))
 def test_tuple_reduce_no_shape_hypothesis(t, shape):
     if isinstance(shape, int):

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -54,6 +54,7 @@ class Tuple(NDIndex):
         array_block_start = False
         array_block_stop = False
         has_array = any(isinstance(i, (ArrayIndex, list, ndarray, bool, bool_)) for i in args)
+        has_boolean_scalar = False
         for arg in args:
             newarg = ndindex(arg)
             if isinstance(newarg, Tuple):
@@ -64,7 +65,7 @@ class Tuple(NDIndex):
             if isinstance(newarg, ArrayIndex):
                 array_block_start = True
                 if newarg in [True, False]:
-                    pass
+                    has_boolean_scalar = True
                 elif isinstance(newarg, BooleanArray):
                     arrays.extend(newarg.raw.nonzero())
                 else:
@@ -88,6 +89,9 @@ class Tuple(NDIndex):
         if newargs.count(ellipsis()) > 1:
             raise IndexError("an index can only have a single ellipsis ('...')")
         if len(arrays) > 0:
+            if has_boolean_scalar:
+                raise NotImplementedError("Tuples mixing boolean scalars (True or False) with arrays are not yet supported.")
+
             try:
                 broadcast(*[i for i in arrays])
             except ValueError as e:

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -489,7 +489,7 @@ class Tuple(NDIndex):
             if isinstance(s, ArrayIndex):
                 if isinstance(s, BooleanArray):
                     begin_offset += s.ndim - 1
-            elif isinstance(s, Integer):
+            elif arrays and isinstance(s, Integer):
                 s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
                                               broadcast_shape), _copy=False)
             elif s == None:
@@ -503,7 +503,7 @@ class Tuple(NDIndex):
             if isinstance(s, ArrayIndex):
                 if isinstance(s, BooleanArray):
                     end_offset -= s.ndim - 1
-            elif isinstance(s, Integer):
+            elif arrays and isinstance(s, Integer):
                 s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
                                               broadcast_shape), _copy=False)
             elif s == None:

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -99,7 +99,7 @@ class Tuple(NDIndex):
         # Since tuples are nested, we can print the raw form of the args to
         # make them a little more readable.
         def _repr(s):
-            if s is Ellipsis:
+            if s == ...:
                 return '...'
             if isinstance(s, ArrayIndex):
                 if s.shape and 0 not in s.shape:
@@ -113,7 +113,7 @@ class Tuple(NDIndex):
         # Since tuples are nested, we can print the raw form of the args to
         # make them a little more readable.
         def _str(s):
-            if s is Ellipsis:
+            if s == ...:
                 return '...'
             if isinstance(s, ArrayIndex):
                 return str(s)

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -493,10 +493,7 @@ class Tuple(NDIndex):
         # assert args.count(False) <= 1
         # assert args.count(True) <= 1
         n_newaxis = args.count(None)
-        n_boolean = sum(1 - len(broadcast_shape) for i in arrays if
-                        isinstance(i, BooleanArray))
-        if True in args or False in args:
-            n_boolean += 1
+        n_boolean = 1 if True in args or False in args else 0
         indexed_args = len(args) - n_boolean - n_newaxis - 1 # -1 for the ellipsis
         shape = asshape(shape, axis=indexed_args - 1)
 

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -83,6 +83,8 @@ class Tuple(NDIndex):
             if s is Ellipsis:
                 return '...'
             if isinstance(s, ArrayIndex):
+                if 0 not in s.shape:
+                    return repr(s.array.tolist())
                 return repr(s)
             return repr(s.raw)
         return f"{self.__class__.__name__}({', '.join(map(_repr, self.args))})"

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -74,14 +74,30 @@ class Tuple(NDIndex):
 
         return tuple(newargs)
 
+
     def __repr__(self):
+        from .array import ArrayIndex
         # Since tuples are nested, we can print the raw form of the args to
         # make them a little more readable.
         def _repr(s):
             if s is Ellipsis:
                 return '...'
-            return repr(s)
-        return f"{self.__class__.__name__}({', '.join(map(_repr, self.raw))})"
+            if isinstance(s, ArrayIndex):
+                return repr(s)
+            return repr(s.raw)
+        return f"{self.__class__.__name__}({', '.join(map(_repr, self.args))})"
+
+    def __str__(self):
+        from .array import ArrayIndex
+        # Since tuples are nested, we can print the raw form of the args to
+        # make them a little more readable.
+        def _str(s):
+            if s is Ellipsis:
+                return '...'
+            if isinstance(s, ArrayIndex):
+                return str(s)
+            return str(s.raw)
+        return f"{self.__class__.__name__}({', '.join(map(_str, self.args))})"
 
     @property
     def has_ellipsis(self):

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -374,7 +374,8 @@ class Tuple(NDIndex):
         - All the elements of the tuple are recursively reduced.
 
         - The length of the .args is equal to the length of the shape plus the
-          number of :any:`Newaxis` indices in `self`.
+          number of :any:`Newaxis` indices in `self` (this is not true if
+          `self` contains :any:`BooleanArray`s).
 
         - The resulting Tuple has no ellipses. Axes that would be matched by
           an ellipsis or an implicit ellipsis at the end of the tuple are

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -48,7 +48,9 @@ class Tuple(NDIndex):
         for arg in args:
             newarg = ndindex(arg)
             if isinstance(newarg, Tuple):
-                raise NotImplementedError("tuples of tuples are not yet supported")
+                if len(args) == 1:
+                    raise ValueError("tuples inside of tuple indices are not supported. Did you mean to call Tuple(*args) instead of Tuple(args)?")
+                raise ValueError("tuples inside of tuple indices are not supported. If you meant to use a fancy index, use a list or array instead.")
             newargs.append(newarg)
 
         if newargs.count(ellipsis()) > 1:

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -460,10 +460,10 @@ class Tuple(NDIndex):
                     # by ellipses, slices, or newaxes affect the shape
                     # differently, but these are currently unsupported (see
                     # the comments in the Tuple constructor)
-                    newshape.extend(list(s.newshape(shape, _axis=axis)))
+                    newshape.extend(list(s.newshape(shape[axis])))
                     arrays = True
             else:
-                newshape.extend(list(s.newshape(shape, _axis=axis)))
+                newshape.extend(list(s.newshape(shape[axis])))
 
         return tuple(newshape)
 

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -61,11 +61,11 @@ class Tuple(NDIndex):
                     raise ValueError("tuples inside of tuple indices are not supported. Did you mean to call Tuple(*args) instead of Tuple(args)?")
                 raise ValueError("tuples inside of tuple indices are not supported. If you meant to use a fancy index, use a list or array instead.")
             newargs.append(newarg)
-            if newarg in [True, False]:
-                pass
-            elif isinstance(newarg, ArrayIndex):
+            if isinstance(newarg, ArrayIndex):
                 array_block_start = True
-                if isinstance(newarg, BooleanArray):
+                if newarg in [True, False]:
+                    pass
+                elif isinstance(newarg, BooleanArray):
                     arrays.extend(newarg.raw.nonzero())
                 else:
                     arrays.append(newarg.raw)

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -444,15 +444,14 @@ class Tuple(NDIndex):
 
         ellipsis_i = self.ellipsis_index
 
-        startshape = []
-        n_newaxis = self.args.count(None)
-        n_newaxis_before_ellipsis = 0
+        newshape = []
+        n_newaxis = 0
         arrays = False
         for i, s in enumerate(self.args[:ellipsis_i]):
-            axis = i-n_newaxis_before_ellipsis
+            axis = i-n_newaxis
             if s == None:
-                n_newaxis_before_ellipsis += 1
-                startshape.append(1)
+                n_newaxis += 1
+                newshape.append(1)
             elif isinstance(s, ArrayIndex):
                 if not arrays:
                     # Multiple arrays are all broadcast together (in expand())
@@ -461,31 +460,10 @@ class Tuple(NDIndex):
                     # by ellipses, slices, or newaxes affect the shape
                     # differently, but these are currently unsupported (see
                     # the comments in the Tuple constructor)
-                    startshape.extend(list(s.newshape(shape, _axis=axis)))
+                    newshape.extend(list(s.newshape(shape, _axis=axis)))
                     arrays = True
             else:
-                startshape.extend(list(s.newshape(shape, _axis=axis)))
-
-        n_newaxis_after_ellipsis = 0
-        endshape = []
-        for i, s in enumerate(reversed(self.args[ellipsis_i+1:]), start=1):
-            axis = len(shape)-i+n_newaxis_after_ellipsis
-            if s == None:
-                n_newaxis_after_ellipsis += 1
-                endshape.append(1)
-            elif isinstance(s, ArrayIndex):
-                if not arrays:
-                    endshape.extend(list(s.newshape(shape, _axis=axis)))
-                    arrays = True
-            else:
-                endshape.extend(list(s.newshape(shape, _axis=axis)))
-
-        if ... in self.args:
-            midshape = list(shape[ellipsis_i-n_newaxis_before_ellipsis:len(shape)+ellipsis_i-len(self.args)+n_newaxis_after_ellipsis+1])
-        else:
-            midshape = list(shape[len(self.args) - n_newaxis:])
-
-        newshape = startshape + midshape + endshape[::-1]
+                newshape.extend(list(s.newshape(shape, _axis=axis)))
 
         return tuple(newshape)
 

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -488,9 +488,9 @@ class Tuple(NDIndex):
             if isinstance(s, ArrayIndex):
                 if isinstance(s, BooleanArray):
                     begin_offset += s.ndim - 1
-                elif isinstance(s, Integer):
-                    s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
-                                                  broadcast_shape), _copy=False)
+            elif isinstance(s, Integer):
+                s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
+                                              broadcast_shape), _copy=False)
             elif s == None:
                 begin_offset -= 1
             newargs.append(s)
@@ -502,9 +502,9 @@ class Tuple(NDIndex):
             if isinstance(s, ArrayIndex):
                 if isinstance(s, BooleanArray):
                     end_offset -= s.ndim - 1
-                elif isinstance(s, Integer):
-                    s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
-                                                  broadcast_shape), _copy=False)
+            elif isinstance(s, Integer):
+                s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
+                                              broadcast_shape), _copy=False)
             elif s == None:
                 end_offset += 1
             axis = len(shape) - i + end_offset

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -357,6 +357,10 @@ class Tuple(NDIndex):
         ...
         IndexError: index -3 is out of bounds for axis 1 with size 2
 
+        >>> idx = Tuple(..., [0, 1], -1)
+        >>> idx.expand((1, 2, 3))
+        Tuple(slice(0, 1, 1), [0, 1], [2, 2])
+
         See Also
         ========
 

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -504,6 +504,8 @@ class Tuple(NDIndex):
                 if isinstance(s, BooleanArray):
                     end_offset -= s.ndim - 1
             elif arrays and isinstance(s, Integer):
+                if (0 in broadcast_shape or False in args):
+                    s = s.reduce(shape, axis=len(shape)-i+end_offset)
                 s = IntegerArray(broadcast_to(array(s.raw, dtype=intp),
                                               broadcast_shape), _copy=False)
             elif s == None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --cov=ndindex/ --cov-report=term-missing --flakes --full-trace
+filterwarnings = error


### PR DESCRIPTION
This is needed for as_subindex support for those indices, which is the main thing we are missing, since an as_subindex result sometimes would be a tuple of arrays. 