### PR TITLE
Install NumPy from git on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pyflakes pytest pytest-doctestplus numpy sympy hypothesis doctr sphinx myst-parser sphinx_rtd_theme pytest-cov pytest-flakes
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pyflakes pytest pytest-doctestplus sympy hypothesis doctr sphinx myst-parser sphinx_rtd_theme pytest-cov pytest-flakes
   - source activate test-environment
+  - pip install git+https://github.com/numpy/numpy.git
 
 script:
   - set -e


### PR DESCRIPTION
This is needed because there are some changes in 1.20 that will make testing a
lot easier. Right now we have to emulate some broken behavior that gives
deprecation warnings in 1.20. Without the deprecation warnings, it is a lot
harder to test because we can't catch the warning.