### PR TITLE
Don't return Slice(None) from Slice.as_subindex(IntegerArray)

### DIFF
--- a/ndindex/slice.py
+++ b/ndindex/slice.py
@@ -411,8 +411,6 @@ class Slice(NDIndex):
             if not res.count_nonzero:
                 raise ValueError("Indices do not intersect")
 
-            if res.array.all() and res.ndim > 0:
-                return Tuple(*[Slice(None)]*res.ndim)
             return res
 
         if not isinstance(index, Slice):

--- a/ndindex/tests/test_assubindex.py
+++ b/ndindex/tests/test_assubindex.py
@@ -11,6 +11,9 @@ from ..tuple import Tuple
 from .helpers import ndindices, short_shapes, assert_equal
 
 
+@example((slice(0, 8), slice(0, 9), slice(0, 10)),
+         ([2, 5, 6, 7], slice(1, 9, 1), slice(5, 10, 1)),
+         (20, 20, 20))
 @example((), (None, array([], dtype=intp)), 0)
 @example((), array([], dtype=bool), 0)
 @example((), IntegerArray(0), 1)

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -685,7 +685,7 @@ class Tuple(NDIndex):
                 else:
                     subindex = self_arg.as_subindex(index_arg)
                     if isinstance(subindex, Tuple):
-                        assert all(i == Slice(None) for i in subindex.args)
+                        assert subindex == ()
                         subindex # Workaround https://github.com/nedbat/coveragepy/issues/1029
                         continue
                     if isinstance(subindex, BooleanArray):


### PR DESCRIPTION
While it is fine for the single slice, it becomes more complicated when there
is a tuple, as multiple integer arrays would be iterated together and
Slice(None) would not. This is not a necessary optimization, so we can remove
it.