### PR TITLE
Add Python 3.9 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
         - CODECOV=true
         # Doctr deploy key for Quansight/ndindex
         - secure: "re3NcmEUC70IlsnSzeSP8SET/Z8VC5r0CLUespXPG0/mDqxulgDRJC3jZMKy/Aa9TkBGW0MTitazIe7zSyuq+UrmNTN1yH8t04fBsQ5Hu8Lh+ed7mhmJqOVBhTX+uaYsHoQ+7LxTaZz4onzfaJBHuzNC7XIchARKPNelz3+TKs8Vlk+K0awtbEgPqpNIo22VOe/dzxs+AtQF1bwdrmfiSRv3LdJNtH+Dzgh1i4euybhylQh+ugWUHVqTKa6FSfXvvvrhZqCUNbVbRjAmGTL2RkucdqRre37Kz3dd6vL7G3zN9tiCI6m6uH+3Z1pEj2rV+y80GZX+CkcSLeGbfqU6S4GewaBW5+p33p4WGKWGvaU2lOu7dJIMwfMTMjzAXPoKSNA42rMzKtArsYAk14mYRKOj082P2sF3bXyy5zvKCG2m6gJseoWQxqU6tZcjUfoKPMUCZQGXJzgHDkzl9vTPfFl2mTY5zvAvC7BYkxUK1uGA6bbTEqGBnfbY9dSDPk5DYDeN5BcAxwBhtnfHiRF+VnhSt2dsG8FE4eL1MyfQn0iSkqd/UHrJOUCBCzGRrw4ZbDhX+S4zv7qNjbonB5UowbpdinePdRf7PUQWGvRvCHoND3se8FITLZktqIcKjB3WvLx7xF9MevVQZhvsRTmOE4MttQ6xbAM0XSzNmehOWVg="
+    - python: 3.9
+      env:
+        - TESTS=true
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
This probably won't work yet because of missing conda packages, but we can
keep trying a rebuild and merge once it does.