### PR TITLE
Add Py39 test, accounting for lack of 3.9.0 tarball on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,15 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history/
+.vscode/
+
+# project scratch dir
+/scratch/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
         - CODECOV=true
         # Doctr deploy key for Quansight/ndindex
         - secure: "re3NcmEUC70IlsnSzeSP8SET/Z8VC5r0CLUespXPG0/mDqxulgDRJC3jZMKy/Aa9TkBGW0MTitazIe7zSyuq+UrmNTN1yH8t04fBsQ5Hu8Lh+ed7mhmJqOVBhTX+uaYsHoQ+7LxTaZz4onzfaJBHuzNC7XIchARKPNelz3+TKs8Vlk+K0awtbEgPqpNIo22VOe/dzxs+AtQF1bwdrmfiSRv3LdJNtH+Dzgh1i4euybhylQh+ugWUHVqTKa6FSfXvvvrhZqCUNbVbRjAmGTL2RkucdqRre37Kz3dd6vL7G3zN9tiCI6m6uH+3Z1pEj2rV+y80GZX+CkcSLeGbfqU6S4GewaBW5+p33p4WGKWGvaU2lOu7dJIMwfMTMjzAXPoKSNA42rMzKtArsYAk14mYRKOj082P2sF3bXyy5zvKCG2m6gJseoWQxqU6tZcjUfoKPMUCZQGXJzgHDkzl9vTPfFl2mTY5zvAvC7BYkxUK1uGA6bbTEqGBnfbY9dSDPk5DYDeN5BcAxwBhtnfHiRF+VnhSt2dsG8FE4eL1MyfQn0iSkqd/UHrJOUCBCzGRrw4ZbDhX+S4zv7qNjbonB5UowbpdinePdRf7PUQWGvRvCHoND3se8FITLZktqIcKjB3WvLx7xF9MevVQZhvsRTmOE4MttQ6xbAM0XSzNmehOWVg="
+    - python: 3.9
+      env:
+        - TESTS=true
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ matrix:
         - CODECOV=true
         # Doctr deploy key for Quansight/ndindex
         - secure: "re3NcmEUC70IlsnSzeSP8SET/Z8VC5r0CLUespXPG0/mDqxulgDRJC3jZMKy/Aa9TkBGW0MTitazIe7zSyuq+UrmNTN1yH8t04fBsQ5Hu8Lh+ed7mhmJqOVBhTX+uaYsHoQ+7LxTaZz4onzfaJBHuzNC7XIchARKPNelz3+TKs8Vlk+K0awtbEgPqpNIo22VOe/dzxs+AtQF1bwdrmfiSRv3LdJNtH+Dzgh1i4euybhylQh+ugWUHVqTKa6FSfXvvvrhZqCUNbVbRjAmGTL2RkucdqRre37Kz3dd6vL7G3zN9tiCI6m6uH+3Z1pEj2rV+y80GZX+CkcSLeGbfqU6S4GewaBW5+p33p4WGKWGvaU2lOu7dJIMwfMTMjzAXPoKSNA42rMzKtArsYAk14mYRKOj082P2sF3bXyy5zvKCG2m6gJseoWQxqU6tZcjUfoKPMUCZQGXJzgHDkzl9vTPfFl2mTY5zvAvC7BYkxUK1uGA6bbTEqGBnfbY9dSDPk5DYDeN5BcAxwBhtnfHiRF+VnhSt2dsG8FE4eL1MyfQn0iSkqd/UHrJOUCBCzGRrw4ZbDhX+S4zv7qNjbonB5UowbpdinePdRf7PUQWGvRvCHoND3se8FITLZktqIcKjB3WvLx7xF9MevVQZhvsRTmOE4MttQ6xbAM0XSzNmehOWVg="
-    - python: 3.9
+    - name: python 3.9
       env:
+        - PYTHON_VERSION=3.9
         - TESTS=true
 
 install:
@@ -30,7 +31,7 @@ install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pyflakes pytest pytest-doctestplus sympy hypothesis doctr sphinx myst-parser=0.11.2 sphinx_rtd_theme pytest-cov pytest-flakes
+  - conda create -n test-environment python=${PYTHON_VERSION:-$TRAVIS_PYTHON_VERSION} pyflakes pytest pytest-doctestplus sympy hypothesis doctr sphinx myst-parser=0.11.2 sphinx_rtd_theme pytest-cov pytest-flakes
   - source activate test-environment
   - pip install git+https://github.com/numpy/numpy.git
 


### PR DESCRIPTION
This builds on/is an alternative to #92, and adds support for a working py3.9 test today (which, happily enough, already passes).

The python 3.9.0 tarball isn't available yet from travis, so this PR sidesteps the issue and sets an independent PYTHON_VERSION var (since the travis python install isn't actually used by the tests). If desired, in a few weeks when the travis people get around to building the 3.9.0 tarball, 72745ae can be reverted to make the config for the 3.9 travis job identical to the rest of the travis jobs, but it shouldn't make a difference